### PR TITLE
DVX:450 Add UtmTags to fluentsearch

### DIFF
--- a/atlan/client/fluent_search.go
+++ b/atlan/client/fluent_search.go
@@ -18,6 +18,18 @@ type FluentSearch struct {
 	Aggregations        map[string]interface{}
 	IncludesOnResults   []string
 	IncludesOnRelations []string
+	UtmTags             []string
+}
+
+// SetUtmTags sets the UTM tags for tracking the source of requests.
+func (fs *FluentSearch) SetUtmTags(tags ...atlan.UTMTags) *FluentSearch {
+	// Convert UTMTags to string before assigning to UtmTags
+	strTags := make([]string, len(tags))
+	for i, tag := range tags {
+		strTags[i] = tag.String()
+	}
+	fs.UtmTags = strTags
+	return fs
 }
 
 type Aggregation struct {
@@ -172,6 +184,7 @@ func (fs *FluentSearch) SortByGuidDefault() *FluentSearch {
 
 // ToRequest converts FluentSearch to IndexSearchRequest.
 func (fs *FluentSearch) ToRequest() *model.IndexSearchRequest {
+
 	// Create a new IndexSearchRequest and set its properties based on FluentSearch
 	request := &model.IndexSearchRequest{
 		SearchRequest: model.SearchRequest{
@@ -237,6 +250,11 @@ func (fs *FluentSearch) ToRequest() *model.IndexSearchRequest {
 			sortItemsJSON[i] = item.ToJSON()
 		}
 		request.Dsl.Sort = sortItemsJSON
+	}
+
+	// Set UtmTags specified by user
+	if fs.UtmTags != nil {
+		request.Metadata.UtmTags = fs.UtmTags
 	}
 
 	return request

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/atlanhq/atlan-go/atlan"
 	"github.com/atlanhq/atlan-go/atlan/client"
 )
 
@@ -21,14 +22,11 @@ func main() {
 		Where(ctx.Column.TYPENAME.Eq("Column")).
 		Where(ctx.Column.TABLE_QUALIFIED_NAME.Eq(assetQualifiedName)).
 		IncludeOnResults("userDescription", "dataType", "isPrimary").
+		SetUtmTags(atlan.PROJECT_SDK_CLI).
 		Execute()
 
-	//fmt.Println(*columnSearchResponse[0].Entities[0].Name)
+	fmt.Println(*columnSearchResponse[0].Entities[0].Name)
 	//fmt.Println(*columnSearchResponse[0].Entities[0].DataType)
-
-	for _, entity := range columnSearchResponse[0].Entities {
-		fmt.Println(entity)
-	}
 
 	qualifiedname := "default/snowflake/1715371897/RAW/WIDEWORLDIMPORTERS_SALESFORCE/FIVETRAN_API_CALL"
 


### PR DESCRIPTION
- Include UtmTags in fluentsearch
- A better developer experience for atlan internal teams  for analytics while developing product with sdk as base.