### PR TITLE
DVX-564: Added support for custom metadata attributes

### DIFF
--- a/atlan/assets/atlan_fields.go
+++ b/atlan/assets/atlan_fields.go
@@ -314,14 +314,18 @@ type CustomMetadataField struct {
 	AttributeDef  model.AttributeDef
 }
 
-func NewCustomMetadataField(setName, attributeName, elasticFieldName string) *CustomMetadataField {
+func NewCustomMetadataField(setName, attributeName string) (*CustomMetadataField, error) {
+	elasticFieldName, err := GetCustomMetadataCache().GetAttrIDForName(setName, attributeName)
+	if err != nil {
+		return nil, err
+	}
 	searchableField := NewSearchableField(attributeName, elasticFieldName)
 	return &CustomMetadataField{
 		SearchableField: searchableField,
 		SetName:         setName,
 		AttributeName:   attributeName,
 		AttributeDef:    GetAttributeDef(elasticFieldName),
-	}
+	}, nil
 }
 
 func (cmf *CustomMetadataField) Eq(value string) model.Query {

--- a/atlan/assets/custom_metadata_cache.go
+++ b/atlan/assets/custom_metadata_cache.go
@@ -2,10 +2,11 @@ package assets
 
 import (
 	"fmt"
-	"github.com/atlanhq/atlan-go/atlan"
-	"github.com/atlanhq/atlan-go/atlan/model"
 	"strings"
 	"sync"
+
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/atlanhq/atlan-go/atlan/model"
 )
 
 /*

--- a/atlan/assets/index_search_client.go
+++ b/atlan/assets/index_search_client.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
+
 	"github.com/atlanhq/atlan-go/atlan"
 	"github.com/atlanhq/atlan-go/atlan/model"
-	"sync"
 )
 
 // Call the search API

--- a/atlan/model/structs/asset.go
+++ b/atlan/model/structs/asset.go
@@ -51,8 +51,6 @@ type MCMonitor string
 
 type File string
 
-type CustomMetadataAttributes string
-
 type SchemaRegistrySubject string
 
 type Metric struct {
@@ -338,7 +336,7 @@ type Asset struct {
 	// Atlan tags assigned to the asset.
 	AtlanTags *[]AtlanTag `json:"classifications,omitempty"`
 	// Map of custom metadata attributes and values defined on the asset.
-	CustomMetadataSets map[string]CustomMetadataAttributes `json:"customMetadataSets,omitempty"`
+	CustomMetadataSets map[string]map[string]interface{} `json:"customMetadataSets,omitempty"`
 	// Time (epoch) at which the asset was created, in milliseconds.
 	CreateTime *int64 `json:"createTime,omitempty"`
 	// Time (epoch) at which the asset was last updated, in milliseconds.

--- a/atlan/utils.go
+++ b/atlan/utils.go
@@ -2,8 +2,9 @@ package atlan
 
 import (
 	"fmt"
-	gonanoid "github.com/matoous/go-nanoid"
 	"time"
+
+	gonanoid "github.com/matoous/go-nanoid"
 )
 
 // GenerateNanoid generates a random string of given length


### PR DESCRIPTION
```go
ctx := assets.NewContext()
// ctx, _ := assets.Context("tenet.atlan.com", "xyz")
ctx.SetLogger(false, "debug")

// Assets with custom metadata
// REF: https://developer.atlan.com/snippets/common-examples/finding/examples/#assets-with-custom-metadata

// cmf, err := assets.NewCustomMetadataField("test-cm", "test-prop")
// if err != nil {
// 	fmt.Println("NewCustomMetadataField error:", err)
// }

// Multiple custom metadata search
cm1 := assets.GetCustomMetadataCache().GetAttributesForSearchResultsByName("test-cm")
cm2 := assets.GetCustomMetadataCache().GetAttributesForSearchResultsByName("test-cm-go")
cmToIncludes := append(cm1, cm2...)

// Glosarry QualifiedName
qualifiedname := "9sdIqSJme1UCuyZYSRQfK"

fs := &assets.FluentSearch{IncludesOnResults: cmToIncludes}
response, atlanErr := fs.
	PageSizes(10).
	AssetType("AtlasGlossary").
	Where(ctx.Glossary.QUALIFIED_NAME.Eq(qualifiedname)).
	// Where(cmf.HasAnyValue()).
	Execute()

if atlanErr != nil {
	fmt.Println(atlanErr)
}

fmt.Println(response[0].ApproximateCount)
fmt.Println(response[0].Entities[0].CustomMetadataSets)

for k, val := range response[0].Entities[0].CustomMetadataSets {
	prop, _ := assets.GetCustomMetadataCache().GetNameForID(k)
	fmt.Println("CM Name", prop, val)

	for s, t := range val {
		prop, _ := assets.GetCustomMetadataCache().GetAttrNameForID(k, s)
		fmt.Println("CM Property", prop, t)
	}
```