### PR TITLE
FT-806: Manage Personas

### DIFF
--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -27,6 +27,9 @@ type SearchAssets struct {
 	Connection       *ConnectionFields
 	MaterialisedView *MaterialisedViewFields
 	View             *ViewFields
+	AccessControl    *AccessControlFields
+	Persona          *PersonaFields
+	AuthPolicy       *AuthPolicyFields
 	// Add other assets here
 }
 
@@ -273,6 +276,35 @@ type AccessControlFields struct {
 	DEFAULT_NAVIGATION         *TextField
 	DISPLAY_PREFERENCES        *KeywordField
 	POLICIES                   *RelationField
+}
+
+type PersonaFields struct {
+	AccessControlFields
+	PERSONA_GROUPS *KeywordField
+	PERSONA_USERS  *KeywordField
+	ROLE_ID        *KeywordField
+}
+
+type AuthPolicyFields struct {
+	AssetFields
+	POLICY_TYPE               *KeywordField
+	POLICY_SERVICE_NAME       *KeywordField
+	POLICY_CATEGORY           *KeywordField
+	POLICY_SUB_CATEGORY       *KeywordField
+	POLICY_USERS              *KeywordField
+	POLICY_GROUPS             *KeywordField
+	POLICY_ROLES              *KeywordField
+	POLICY_ACTIONS            *KeywordField
+	POLICY_RESOURCES          *KeywordField
+	POLICY_RESOURCE_CATEGORY  *KeywordField
+	POLICY_PRIORITY           *NumericField
+	IS_POLICY_ENABLED         *BooleanField
+	POLICY_MASK_TYPE          *KeywordField
+	POLICY_VALIDITY_SCHEDULE  *KeywordField
+	POLICY_RESOURCE_SIGNATURE *KeywordField
+	POLICY_DELEGATE_ADMIN     *BooleanField
+	POLICY_CONDITIONS         *KeywordField
+	ACCESS_CONTROL            *RelationField
 }
 
 // NewSearchTable returns a new AtlasTable object for Searching
@@ -803,6 +835,119 @@ func NewAccessControlFields() *AccessControlFields {
 			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
 		},
+	}
+}
+
+// NewPersonaFields initializes a new instance of PersonaFields.
+func NewPersonaFields() *PersonaFields {
+	return &PersonaFields{
+		AccessControlFields: AccessControlFields{
+			IS_ACCESS_CONTROL_ENABLED:  NewBooleanField("isAccessControlEnabled", "isAccessControlEnabled"),
+			DENY_CUSTOM_METADATA_GUIDS: NewKeywordField("denyCustomMetadataGuids", "denyCustomMetadataGuids"),
+			DENY_ASSET_TABS:            NewKeywordField("denyAssetTabs", "denyAssetTabs"),
+			DENY_ASSET_FILTERS:         NewTextField("denyAssetFilters", "denyAssetFilters"),
+			CHANNEL_LINK:               NewTextField("channelLink", "channelLink"),
+			DENY_ASSET_TYPES:           NewTextField("denyAssetTypes", "denyAssetTypes"),
+			DENY_NAVIGATION_PAGES:      NewTextField("denyNavigationPages", "denyNavigationPages"),
+			DEFAULT_NAVIGATION:         NewTextField("defaultNavigation", "defaultNavigation"),
+			DISPLAY_PREFERENCES:        NewKeywordField("displayPreferences", "displayPreferences"),
+			POLICIES:                   NewRelationField("policies"),
+			AssetFields: AssetFields{
+				AttributesFields: AttributesFields{
+					TYPENAME:              NewKeywordTextField("typeName", "__typeName.keyword", "__typeName"),
+					GUID:                  NewKeywordField("guid", "__guid"),
+					CREATED_BY:            NewKeywordField("createdBy", "__createdBy"),
+					UPDATED_BY:            NewKeywordField("updatedBy", "__modifiedBy"),
+					STATUS:                NewKeywordField("status", "__state"),
+					ATLAN_TAGS:            NewKeywordTextField("classificationNames", "__traitNames", "__classificationsText"),
+					PROPOGATED_ATLAN_TAGS: NewKeywordTextField("classificationNames", "__propagatedTraitNames", "__classificationsText"),
+					ASSIGNED_TERMS:        NewKeywordTextField("meanings", "__meanings", "__meaningsText"),
+					SUPERTYPE_NAMES:       NewKeywordTextField("typeName", "__superTypeNames.keyword", "__superTypeNames"),
+					CREATE_TIME:           NewNumericField("createTime", "__timestamp"),
+					UPDATE_TIME:           NewNumericField("updateTime", "__modificationTimestamp"),
+					QUALIFIED_NAME:        NewKeywordTextField("qualifiedName", "qualifiedName", "qualifiedName.text"),
+				},
+				NAME:                       NewKeywordTextStemmedField("name", "name.keyword", "name", "name"),
+				DISPLAY_NAME:               NewKeywordTextField("displayName", "displayName.keyword", "displayName"),
+				DESCRIPTION:                NewKeywordTextField("description", "description", "description.text"),
+				USER_DESCRIPTION:           NewKeywordTextField("userDescription", "userDescription", "userDescription.text"),
+				TENET_ID:                   NewKeywordField("tenetId", "tenetId"),
+				CERTIFICATE_STATUS:         NewKeywordTextField("certificateStatus", "certificateStatus", "certificateStatus.text"),
+				CERTIFICATE_STATUS_MESSAGE: NewKeywordField("certificateStatusMessage", "certificateStatusMessage"),
+				CERTIFICATE_UPDATED_BY:     NewNumericField("certificateUpdatedBy", "certificateUpdatedBy"),
+				ANNOUNCEMENT_TITLE:         NewKeywordField("announcementTitle", "announcementTitle"),
+				ANNOUNCEMENT_MESSAGE:       NewKeywordTextField("announcementMessage", "announcementMessage", "announcementMessage.text"),
+				ANNOUNCEMENT_TYPE:          NewKeywordField("announcementType", "announcementType"),
+				ANNOUNCEMENT_UPDATED_AT:    NewNumericField("announcementUpdatedAt", "announcementUpdatedAt"),
+				ANNOUNCEMENT_UPDATED_BY:    NewKeywordField("announcementUpdatedBy", "announcementUpdatedBy"),
+				OWNER_USERS:                NewKeywordTextField("ownerUsers", "ownerUsers", "ownerUsers.text"),
+				ADMIN_USERS:                NewKeywordField("adminUsers", "adminUsers"),
+				VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
+				VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
+				CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+			},
+		},
+		PERSONA_GROUPS: NewKeywordField("personaGroups", "personaGroups"),
+		PERSONA_USERS:  NewKeywordField("personaUsers", "personaUsers"),
+		ROLE_ID:        NewKeywordField("roleId", "roleId"),
+	}
+}
+
+// NewAuthPolicyFields initializes a new instance of AuthPolicyFields.
+func NewAuthPolicyFields() *AuthPolicyFields {
+	return &AuthPolicyFields{
+		AssetFields: AssetFields{
+			AttributesFields: AttributesFields{
+				TYPENAME:              NewKeywordTextField("typeName", "__typeName.keyword", "__typeName"),
+				GUID:                  NewKeywordField("guid", "__guid"),
+				CREATED_BY:            NewKeywordField("createdBy", "__createdBy"),
+				UPDATED_BY:            NewKeywordField("updatedBy", "__modifiedBy"),
+				STATUS:                NewKeywordField("status", "__state"),
+				ATLAN_TAGS:            NewKeywordTextField("classificationNames", "__traitNames", "__classificationsText"),
+				PROPOGATED_ATLAN_TAGS: NewKeywordTextField("classificationNames", "__propagatedTraitNames", "__classificationsText"),
+				ASSIGNED_TERMS:        NewKeywordTextField("meanings", "__meanings", "__meaningsText"),
+				SUPERTYPE_NAMES:       NewKeywordTextField("typeName", "__superTypeNames.keyword", "__superTypeNames"),
+				CREATE_TIME:           NewNumericField("createTime", "__timestamp"),
+				UPDATE_TIME:           NewNumericField("updateTime", "__modificationTimestamp"),
+				QUALIFIED_NAME:        NewKeywordTextField("qualifiedName", "qualifiedName", "qualifiedName.text"),
+			},
+			NAME:                       NewKeywordTextStemmedField("name", "name.keyword", "name", "name"),
+			DISPLAY_NAME:               NewKeywordTextField("displayName", "displayName.keyword", "displayName"),
+			DESCRIPTION:                NewKeywordTextField("description", "description", "description.text"),
+			USER_DESCRIPTION:           NewKeywordTextField("userDescription", "userDescription", "userDescription.text"),
+			TENET_ID:                   NewKeywordField("tenetId", "tenetId"),
+			CERTIFICATE_STATUS:         NewKeywordTextField("certificateStatus", "certificateStatus", "certificateStatus.text"),
+			CERTIFICATE_STATUS_MESSAGE: NewKeywordField("certificateStatusMessage", "certificateStatusMessage"),
+			CERTIFICATE_UPDATED_BY:     NewNumericField("certificateUpdatedBy", "certificateUpdatedBy"),
+			ANNOUNCEMENT_TITLE:         NewKeywordField("announcementTitle", "announcementTitle"),
+			ANNOUNCEMENT_MESSAGE:       NewKeywordTextField("announcementMessage", "announcementMessage", "announcementMessage.text"),
+			ANNOUNCEMENT_TYPE:          NewKeywordField("announcementType", "announcementType"),
+			ANNOUNCEMENT_UPDATED_AT:    NewNumericField("announcementUpdatedAt", "announcementUpdatedAt"),
+			ANNOUNCEMENT_UPDATED_BY:    NewKeywordField("announcementUpdatedBy", "announcementUpdatedBy"),
+			OWNER_USERS:                NewKeywordTextField("ownerUsers", "ownerUsers", "ownerUsers.text"),
+			ADMIN_USERS:                NewKeywordField("adminUsers", "adminUsers"),
+			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
+			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
+			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+		},
+		POLICY_TYPE:               NewKeywordField("policyType", "policyType"),
+		POLICY_SERVICE_NAME:       NewKeywordField("policyServiceName", "policyServiceName"),
+		POLICY_CATEGORY:           NewKeywordField("policyCategory", "policyCategory"),
+		POLICY_SUB_CATEGORY:       NewKeywordField("policySubCategory", "policySubCategory"),
+		POLICY_USERS:              NewKeywordField("policyUsers", "policyUsers"),
+		POLICY_GROUPS:             NewKeywordField("policyGroups", "policyGroups"),
+		POLICY_ROLES:              NewKeywordField("policyRoles", "policyRoles"),
+		POLICY_ACTIONS:            NewKeywordField("policyActions", "policyActions"),
+		POLICY_RESOURCES:          NewKeywordField("policyResources", "policyResources"),
+		POLICY_RESOURCE_CATEGORY:  NewKeywordField("policyResourceCategory", "policyResourceCategory"),
+		POLICY_PRIORITY:           NewNumericField("policyPriority", "policyPriority"),
+		IS_POLICY_ENABLED:         NewBooleanField("isPolicyEnabled", "isPolicyEnabled"),
+		POLICY_MASK_TYPE:          NewKeywordField("policyMaskType", "policyMaskType"),
+		POLICY_VALIDITY_SCHEDULE:  NewKeywordField("policyValiditySchedule", "policyValiditySchedule"),
+		POLICY_RESOURCE_SIGNATURE: NewKeywordField("policyResourceSignature", "policyResourceSignature"),
+		POLICY_DELEGATE_ADMIN:     NewBooleanField("policyDelegateAdmin", "policyDelegateAdmin"),
+		POLICY_CONDITIONS:         NewKeywordField("policyConditions", "policyConditions"),
+		ACCESS_CONTROL:            NewRelationField("accessControl"),
 	}
 }
 

--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -228,6 +228,20 @@ type ConnectionFields struct {
 	VECTOR_EMBEDDINGS_UPDATED_AT    *NumericField
 }
 
+type AccessControlFields struct {
+	AssetFields
+	IS_ACCESS_CONTROL_ENABLED  *BooleanField
+	DENY_CUSTOM_METADATA_GUIDS *KeywordField
+	DENY_ASSET_TABS            *KeywordField
+	DENY_ASSET_FILTERS         *TextField
+	CHANNEL_LINK               *TextField
+	DENY_ASSET_TYPES           *TextField
+	DENY_NAVIGATION_PAGES      *TextField
+	DEFAULT_NAVIGATION         *TextField
+	DISPLAY_PREFERENCES        *KeywordField
+	POLICIES                   *RelationField
+}
+
 type MaterialisedViewFields struct {
 	SQLFields
 	REFRESH_MODE         *KeywordField
@@ -740,6 +754,56 @@ func NewSearchView() *ViewFields {
 		ATLAN_SCHEMA:         NewRelationField("atlanSchema"),
 	}
 
+}
+
+// NewAccessControlFields initializes a new instance of AccessControlFields.
+func NewAccessControlFields() *AccessControlFields {
+	return &AccessControlFields{
+		IS_ACCESS_CONTROL_ENABLED:  NewBooleanField("isAccessControlEnabled", "isAccessControlEnabled"),
+		DENY_CUSTOM_METADATA_GUIDS: NewKeywordField("denyCustomMetadataGuids", "denyCustomMetadataGuids"),
+		DENY_ASSET_TABS:            NewKeywordField("denyAssetTabs", "denyAssetTabs"),
+		DENY_ASSET_FILTERS:         NewTextField("denyAssetFilters", "denyAssetFilters"),
+		CHANNEL_LINK:               NewTextField("channelLink", "channelLink"),
+		DENY_ASSET_TYPES:           NewTextField("denyAssetTypes", "denyAssetTypes"),
+		DENY_NAVIGATION_PAGES:      NewTextField("denyNavigationPages", "denyNavigationPages"),
+		DEFAULT_NAVIGATION:         NewTextField("defaultNavigation", "defaultNavigation"),
+		DISPLAY_PREFERENCES:        NewKeywordField("displayPreferences", "displayPreferences"),
+		POLICIES:                   NewRelationField("policies"),
+		AssetFields: AssetFields{
+			AttributesFields: AttributesFields{
+				TYPENAME:              NewKeywordTextField("typeName", "__typeName.keyword", "__typeName"),
+				GUID:                  NewKeywordField("guid", "__guid"),
+				CREATED_BY:            NewKeywordField("createdBy", "__createdBy"),
+				UPDATED_BY:            NewKeywordField("updatedBy", "__modifiedBy"),
+				STATUS:                NewKeywordField("status", "__state"),
+				ATLAN_TAGS:            NewKeywordTextField("classificationNames", "__traitNames", "__classificationsText"),
+				PROPOGATED_ATLAN_TAGS: NewKeywordTextField("classificationNames", "__propagatedTraitNames", "__classificationsText"),
+				ASSIGNED_TERMS:        NewKeywordTextField("meanings", "__meanings", "__meaningsText"),
+				SUPERTYPE_NAMES:       NewKeywordTextField("typeName", "__superTypeNames.keyword", "__superTypeNames"),
+				CREATE_TIME:           NewNumericField("createTime", "__timestamp"),
+				UPDATE_TIME:           NewNumericField("updateTime", "__modificationTimestamp"),
+				QUALIFIED_NAME:        NewKeywordTextField("qualifiedName", "qualifiedName", "qualifiedName.text"),
+			},
+			NAME:                       NewKeywordTextStemmedField("name", "name.keyword", "name", "name"),
+			DISPLAY_NAME:               NewKeywordTextField("displayName", "displayName.keyword", "displayName"),
+			DESCRIPTION:                NewKeywordTextField("description", "description", "description.text"),
+			USER_DESCRIPTION:           NewKeywordTextField("userDescription", "userDescription", "userDescription.text"),
+			TENET_ID:                   NewKeywordField("tenetId", "tenetId"),
+			CERTIFICATE_STATUS:         NewKeywordTextField("certificateStatus", "certificateStatus", "certificateStatus.text"),
+			CERTIFICATE_STATUS_MESSAGE: NewKeywordField("certificateStatusMessage", "certificateStatusMessage"),
+			CERTIFICATE_UPDATED_BY:     NewNumericField("certificateUpdatedBy", "certificateUpdatedBy"),
+			ANNOUNCEMENT_TITLE:         NewKeywordField("announcementTitle", "announcementTitle"),
+			ANNOUNCEMENT_MESSAGE:       NewKeywordTextField("announcementMessage", "announcementMessage", "announcementMessage.text"),
+			ANNOUNCEMENT_TYPE:          NewKeywordField("announcementType", "announcementType"),
+			ANNOUNCEMENT_UPDATED_AT:    NewNumericField("announcementUpdatedAt", "announcementUpdatedAt"),
+			ANNOUNCEMENT_UPDATED_BY:    NewKeywordField("announcementUpdatedBy", "announcementUpdatedBy"),
+			OWNER_USERS:                NewKeywordTextField("ownerUsers", "ownerUsers", "ownerUsers.text"),
+			ADMIN_USERS:                NewKeywordField("adminUsers", "adminUsers"),
+			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
+			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
+			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+		},
+	}
 }
 
 // Methods on assets

--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -228,20 +228,6 @@ type ConnectionFields struct {
 	VECTOR_EMBEDDINGS_UPDATED_AT    *NumericField
 }
 
-type AccessControlFields struct {
-	AssetFields
-	IS_ACCESS_CONTROL_ENABLED  *BooleanField
-	DENY_CUSTOM_METADATA_GUIDS *KeywordField
-	DENY_ASSET_TABS            *KeywordField
-	DENY_ASSET_FILTERS         *TextField
-	CHANNEL_LINK               *TextField
-	DENY_ASSET_TYPES           *TextField
-	DENY_NAVIGATION_PAGES      *TextField
-	DEFAULT_NAVIGATION         *TextField
-	DISPLAY_PREFERENCES        *KeywordField
-	POLICIES                   *RelationField
-}
-
 type MaterialisedViewFields struct {
 	SQLFields
 	REFRESH_MODE         *KeywordField
@@ -273,6 +259,20 @@ type ViewFields struct {
 	COLUMNS              *RelationField
 	QUERIES              *RelationField
 	ATLAN_SCHEMA         *RelationField
+}
+
+type AccessControlFields struct {
+	AssetFields
+	IS_ACCESS_CONTROL_ENABLED  *BooleanField
+	DENY_CUSTOM_METADATA_GUIDS *KeywordField
+	DENY_ASSET_TABS            *KeywordField
+	DENY_ASSET_FILTERS         *TextField
+	CHANNEL_LINK               *TextField
+	DENY_ASSET_TYPES           *TextField
+	DENY_NAVIGATION_PAGES      *TextField
+	DEFAULT_NAVIGATION         *TextField
+	DISPLAY_PREFERENCES        *KeywordField
+	POLICIES                   *RelationField
 }
 
 // NewSearchTable returns a new AtlasTable object for Searching

--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/atlanhq/atlan-go/atlan"
 	"hash/fnv"
 	"reflect"
 	"strings"
@@ -1345,4 +1346,41 @@ func TrimToRequired(asset model.SearchAssets) (*model.SearchAssets, error) {
 	}
 
 	return instance, nil
+}
+
+// BaseEntity represents the base entity structure returned by the Atlan while fetching an entity.
+type BaseEntity struct {
+	ReferredEntities map[string]interface{} `json:"referredEntities"`
+	Entity           Entity                 `json:"entity"`
+}
+
+type Entity struct {
+	TypeName               string            `json:"typeName"`
+	AttributesJSON         json.RawMessage   `json:"attributes"`
+	Guid                   string            `json:"guid"`
+	IsIncomplete           bool              `json:"isIncomplete"`
+	Status                 atlan.AtlanStatus `json:"status"`
+	CreatedBy              string            `json:"createdBy"`
+	UpdatedBy              string            `json:"updatedBy"`
+	CreateTime             int64             `json:"createTime"`
+	UpdateTime             int64             `json:"updateTime"`
+	Version                int               `json:"version"`
+	RelationshipAttributes json.RawMessage   `json:"relationshipAttributes"`
+	Labels                 []interface{}     `json:"labels"`
+}
+
+// UnmarshalBaseEntity unmarshals the base entity and the attributes into the specific entity struct.
+func UnmarshalBaseEntity(data []byte, entity interface{}) (*BaseEntity, error) {
+	// Unmarshal the base entity.
+	var base BaseEntity
+	if err := json.Unmarshal(data, &base); err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the attributes into the specific entity struct.
+	if err := json.Unmarshal(base.Entity.AttributesJSON, entity); err != nil {
+		return nil, err
+	}
+
+	return &base, nil
 }

--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -964,7 +964,7 @@ func GetByGuid[T AtlanObject](guid string) (T, error) {
 	}
 
 	api := &GET_ENTITY_BY_GUID
-	api.Path += guid
+	api.Path = fmt.Sprintf("entity/guid/%s", guid) // Adjust to the actual API path structure
 
 	response, err := DefaultAtlanClient.CallAPI(api, nil, nil)
 	if err != nil {

--- a/atlan/assets/auth_policy_client.go
+++ b/atlan/assets/auth_policy_client.go
@@ -1,0 +1,152 @@
+package assets
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/atlanhq/atlan-go/atlan/model/structs"
+)
+
+type AuthPolicy structs.AuthPolicy
+
+func (a *AuthPolicy) Updater(name string, qualifiedName string) error {
+	if name == "" || qualifiedName == "" {
+		return errors.New("name, qualifiedName are required fields")
+	}
+
+	a.Name = &name
+	a.QualifiedName = &qualifiedName
+
+	return nil
+}
+
+func (a *AuthPolicy) UnmarshalJSON(data []byte) error {
+	// Define a temporary structure with the expected JSON structure.
+	var temp struct {
+		ReferredEntities map[string]interface{} `json:"referredEntities"`
+		Entity           struct {
+			TypeName               string            `json:"typeName"`
+			AttributesJSON         json.RawMessage   `json:"attributes"`
+			Guid                   string            `json:"guid"`
+			IsIncomplete           bool              `json:"isIncomplete"`
+			Status                 atlan.AtlanStatus `json:"status"`
+			CreatedBy              string            `json:"createdBy"`
+			UpdatedBy              string            `json:"updatedBy"`
+			CreateTime             int64             `json:"createTime"`
+			UpdateTime             int64             `json:"updateTime"`
+			Version                int               `json:"version"`
+			RelationshipAttributes struct {
+				SchemaRegistrySubjects []structs.SchemaRegistrySubject `json:"schemaRegistrySubjects"`
+				McMonitors             []structs.MCMonitor             `json:"mcMonitors"`
+				Terms                  []structs.AtlasGlossaryTerm     `json:"terms"`
+				OutputPortDataProducts []string                        `json:"outputPortDataProducts"`
+				AtlasGlossary          []structs.AtlasGlossary         `json:"AtlasGlossary"`
+				AccessControl          []structs.AccessControl         `json:"AccessControl"`
+				Policies               []structs.AuthPolicy            `json:"policies"`
+			} `json:"relationshipAttributes"`
+		}
+	}
+
+	// Unmarshal the JSON data into the temporary structure.
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	// Unmarshal the attributes JSON into the entity.
+	if err := json.Unmarshal(temp.Entity.AttributesJSON, &a); err != nil {
+		return err
+	}
+
+	// Set the GUID and TypeName.
+	a.Guid = &temp.Entity.Guid
+	a.TypeName = &temp.Entity.TypeName
+
+	return nil
+}
+
+func (a *AuthPolicy) MarshalJSON() ([]byte, error) {
+	// Marshal the AccessControl asset into a JSON object.
+
+	// Construct the custom JSON structure
+	customJSON := map[string]interface{}{
+		"typeName": "AuthPolicy",
+		"attributes": map[string]interface{}{
+			"name":          a.Name,
+			"qualifiedName": a.Name,
+			// Add other attributes as necessary.
+		},
+	}
+
+	attributes := customJSON["attributes"].(map[string]interface{})
+
+	if a.QualifiedName != nil && *a.QualifiedName != "" {
+		attributes["qualifiedName"] = *a.QualifiedName
+	}
+
+	//	if a.Guid != nil && *a.Guid != "" {
+	//		customJSON["guid"] = *a.Guid
+	//	}
+
+	if a.DisplayName != nil && *a.DisplayName != "" {
+		attributes["displayName"] = *a.DisplayName
+	}
+
+	if a.PolicyType != nil {
+		attributes["policyType"] = *a.PolicyType
+	}
+
+	if a.PolicyCategory != nil && *a.PolicyCategory != "" {
+		attributes["policyCategory"] = *a.PolicyCategory
+	}
+
+	if a.PolicyResources != nil {
+		attributes["policyResources"] = *a.PolicyResources
+	}
+
+	if a.PolicyActions != nil {
+		attributes["policyActions"] = *a.PolicyActions
+	}
+
+	if a.PolicyResourceCategory != nil && *a.PolicyResourceCategory != "" {
+		attributes["policyResourceCategory"] = *a.PolicyResourceCategory
+	}
+
+	if a.PolicyServiceName != nil && *a.PolicyServiceName != "" {
+		attributes["policyServiceName"] = *a.PolicyServiceName
+	}
+
+	if a.PolicySubCategory != nil && *a.PolicySubCategory != "" {
+		attributes["policySubCategory"] = *a.PolicySubCategory
+	}
+
+	if a.ConnectionQualifiedName != nil && *a.ConnectionQualifiedName != "" {
+		attributes["connectionQualifiedName"] = *a.ConnectionQualifiedName
+	}
+
+	// Handle nested AccessControl field
+	if a.AccessControl != nil {
+		accessControl := map[string]interface{}{}
+
+		if a.AccessControl.Guid != nil && *a.AccessControl.Guid != "" {
+			accessControl["guid"] = *a.AccessControl.Guid
+		}
+
+		if a.AccessControl.TypeName != nil && *a.AccessControl.TypeName != "" {
+			accessControl["typeName"] = *a.AccessControl.TypeName
+		}
+
+		attributes["accessControl"] = accessControl
+	}
+
+	return json.MarshalIndent(customJSON, "", "  ")
+}
+
+func (a *AuthPolicy) ToJSON() ([]byte, error) {
+	// Marshal the Persona object into a JSON object.
+	return json.Marshal(a)
+}
+
+func (a *AuthPolicy) FromJSON(data []byte) error {
+	// Unmarshal the JSON data into the Persona object.
+	return json.Unmarshal(data, a)
+}

--- a/atlan/assets/client.go
+++ b/atlan/assets/client.go
@@ -457,6 +457,19 @@ func (ac *AtlanClient) CallAPI(api *API, queryParams interface{}, requestObj int
 
 	// Handle API error based on response status code
 	if response.StatusCode != api.Status {
+		body, readErr := io.ReadAll(response.Body)
+		if readErr != nil {
+			fmt.Printf("Error reading response body: %v\n", readErr)
+			return nil, handleApiError(response, fmt.Errorf("error reading response body: %v", readErr))
+		}
+
+		// Create a descriptive error if `err` is nil
+		var errorMessage string
+		if err == nil {
+			errorMessage = fmt.Sprintf("API returned status code %d: %s", response.StatusCode, string(body))
+			err = fmt.Errorf(errorMessage)
+			//	fmt.Printf("Constructed error: %s\n", errorMessage) // Optional for debugging
+		}
 		return nil, handleApiError(response, err)
 	}
 

--- a/atlan/assets/client.go
+++ b/atlan/assets/client.go
@@ -132,6 +132,9 @@ func newDefaultSearchAssets() SearchAssets {
 		Connection:       NewSearchConnection(),
 		MaterialisedView: NewSearchMaterialisedView(),
 		View:             NewSearchView(),
+		Persona:          NewPersonaFields(),
+		AccessControl:    NewAccessControlFields(),
+		AuthPolicy:       NewAuthPolicyFields(),
 	}
 }
 

--- a/atlan/assets/glossary_client.go
+++ b/atlan/assets/glossary_client.go
@@ -17,130 +17,106 @@ const (
 type AtlasGlossary structs.AtlasGlossary
 
 // Creator is used to create a new glossary asset in memory.
-func (g *AtlasGlossary) Creator(name string, icon atlan.AtlanIcon) {
-	g.TypeName = structs.StringPtr("AtlasGlossary")
-	g.Name = structs.StringPtr(name)
-	g.QualifiedName = structs.StringPtr(name)
-	g.AssetIcon = atlan.AtlanIconPtr(icon)
+func (ag *AtlasGlossary) Creator(name string, icon atlan.AtlanIcon) {
+	ag.TypeName = structs.StringPtr("AtlasGlossary")
+	ag.Name = structs.StringPtr(name)
+	ag.QualifiedName = structs.StringPtr(name)
+	ag.AssetIcon = atlan.AtlanIconPtr(icon)
 }
 
 // Updater is used to modify a glossary asset in memory.
-func (g *AtlasGlossary) Updater(name string, qualifiedName string, glossary_guid string) error {
+func (ag *AtlasGlossary) Updater(name string, qualifiedName string, glossary_guid string) error {
 	if name == "" || qualifiedName == "" || glossary_guid == "" {
 		return errors.New("name, qualified_name, and glossary_guid are required fields")
 	}
 
-	g.TypeName = structs.StringPtr("AtlasGlossary")
-	g.Name = structs.StringPtr(name)
-	g.Guid = structs.StringPtr(glossary_guid)
-	g.QualifiedName = structs.StringPtr(qualifiedName)
+	ag.TypeName = structs.StringPtr("AtlasGlossary")
+	ag.Name = structs.StringPtr(name)
+	ag.Guid = structs.StringPtr(glossary_guid)
+	ag.QualifiedName = structs.StringPtr(qualifiedName)
 
 	return nil
 }
 
 func (ag *AtlasGlossary) UnmarshalJSON(data []byte) error {
-	// Define a temporary structure with the expected JSON structure.
-	var temp struct {
-		ReferredEntities map[string]interface{} `json:"referredEntities"`
-		Entity           struct {
-			TypeName               string            `json:"typeName"`
-			AttributesJSON         json.RawMessage   `json:"attributes"`
-			Guid                   string            `json:"guid"`
-			IsIncomplete           bool              `json:"isIncomplete"`
-			Status                 atlan.AtlanStatus `json:"status"`
-			CreatedBy              string            `json:"createdBy"`
-			UpdatedBy              string            `json:"updatedBy"`
-			CreateTime             int64             `json:"createTime"`
-			UpdateTime             int64             `json:"updateTime"`
-			Version                int               `json:"version"`
-			RelationshipAttributes struct {
-				SchemaRegistrySubjects []structs.SchemaRegistrySubject `json:"schemaRegistrySubjects"`
-				McMonitors             []structs.MCMonitor             `json:"mcMonitors"`
-				Terms                  []structs.AtlasGlossaryTerm     `json:"terms"`
-				OutputPortDataProducts []string                        `json:"outputPortDataProducts"`
-				Files                  []structs.File                  `json:"files"`
-				McIncidents            []structs.MCIncident            `json:"mcIncidents"`
-				Links                  []structs.Link                  `json:"links"`
-				Categories             []structs.AtlasGlossaryCategory `json:"categories"`
-				Metrics                []structs.Metric                `json:"metrics"`
-				Readme                 []structs.Readme                `json:"readme"`
-				Meanings               []structs.Meaning               `json:"meanings"`
-				SodaChecks             []structs.SodaCheck             `json:"sodaChecks"`
-			} `json:"relationshipAttributes"`
-			Labels []interface{} `json:"labels"`
-		} `json:"entity"`
-	}
 
-	// Unmarshal the JSON into the temporary structure
-	if err := json.Unmarshal(data, &temp); err != nil {
+	Attributes := struct {
+		Name             *string          `json:"name"`
+		QualifiedName    *string          `json:"qualifiedName"`
+		AssetIcon        *atlan.AtlanIcon `json:"assetIcon"`
+		ShortDescription *string          `json:"shortDescription"`
+		LongDescription  *string          `json:"longDescription"`
+		Language         *string          `json:"language"`
+		Usage            *string          `json:"usage"`
+		// Add other attributes as necessary.
+	}{}
+
+	base, err := UnmarshalBaseEntity(data, &Attributes)
+	if err != nil {
 		return err
 	}
 
-	// Map the fields from the temporary structure to your AtlasGlossary struct
-	ag.TypeName = &temp.Entity.TypeName
-	ag.Guid = &temp.Entity.Guid
-	ag.IsIncomplete = &temp.Entity.IsIncomplete
-	ag.Status = &temp.Entity.Status
-	ag.CreatedBy = &temp.Entity.CreatedBy
-	ag.UpdatedBy = &temp.Entity.UpdatedBy
-	ag.CreateTime = &temp.Entity.CreateTime
-	ag.UpdateTime = &temp.Entity.UpdateTime
+	// Map Shared Fields
+	ag.TypeName = &base.Entity.TypeName
+	ag.Guid = &base.Entity.Guid
+	ag.IsIncomplete = &base.Entity.IsIncomplete
+	ag.Status = &base.Entity.Status
+	ag.CreatedBy = &base.Entity.CreatedBy
+	ag.UpdatedBy = &base.Entity.UpdatedBy
+	ag.CreateTime = &base.Entity.CreateTime
+	ag.UpdateTime = &base.Entity.UpdateTime
 
-	var asset structs.AtlasGlossaryAttributes
-	if err := json.Unmarshal(temp.Entity.AttributesJSON, &asset); err != nil {
-		return err
-	}
-
-	// Map Asset fields
-	ag.Name = asset.Name
-	ag.AssetIcon = asset.AssetIcon
-	ag.QualifiedName = asset.QualifiedName
-	ag.ShortDescription = asset.ShortDescription
-	ag.LongDescription = asset.LongDescription
-	ag.Language = asset.Language
-	ag.Usage = asset.Usage
-	ag.AssetIcon = asset.AssetIcon
+	// Map Attribute fields
+	ag.Name = Attributes.Name
+	ag.QualifiedName = Attributes.QualifiedName
+	ag.ShortDescription = Attributes.ShortDescription
+	ag.LongDescription = Attributes.LongDescription
+	ag.Language = Attributes.Language
+	ag.Usage = Attributes.Usage
+	ag.AssetIcon = Attributes.AssetIcon
 
 	return nil
 }
 
 // MarshalJSON filters out entities to only include those with non-empty attributes.
-func (g *AtlasGlossary) MarshalJSON() ([]byte, error) {
+func (ag *AtlasGlossary) MarshalJSON() ([]byte, error) {
 	// Construct the custom JSON structure
 	customJSON := map[string]interface{}{
 		"typeName": "AtlasGlossary",
 		"attributes": map[string]interface{}{
-			"name": g.Name,
+			"name": ag.Name,
 			// Add other attributes as necessary.
 		},
 		"relationshipAttributes": make(map[string]interface{}),
 	}
 
-	if g.QualifiedName != nil && *g.QualifiedName != "" {
-		customJSON["attributes"].(map[string]interface{})["qualifiedName"] = *g.QualifiedName
+	attributes := customJSON["attributes"].(map[string]interface{})
+
+	if ag.QualifiedName != nil && *ag.QualifiedName != "" {
+		attributes["qualifiedName"] = *ag.QualifiedName
 	}
 
-	if g.Guid != nil && *g.Guid != "" {
-		customJSON["guid"] = *g.Guid
+	if ag.Guid != nil && *ag.Guid != "" {
+		customJSON["guid"] = *ag.Guid
 	}
 
-	if g.DisplayName != nil && *g.DisplayName != "" {
-		customJSON["attributes"].(map[string]interface{})["displayName"] = *g.DisplayName
+	if ag.DisplayName != nil && *ag.DisplayName != "" {
+		attributes["displayName"] = *ag.DisplayName
 	}
-	if g.Description != nil && *g.Description != "" {
-		customJSON["attributes"].(map[string]interface{})["description"] = *g.Description
+	if ag.Description != nil && *ag.Description != "" {
+		attributes["description"] = *ag.Description
 	}
-	if g.AnnouncementType != nil {
-		customJSON["attributes"].(map[string]interface{})["announcementType"] = *g.AnnouncementType
+	if ag.AnnouncementType != nil {
+		attributes["announcementType"] = *ag.AnnouncementType
 	}
-	if g.AnnouncementTitle != nil && *g.AnnouncementTitle != "" {
-		customJSON["attributes"].(map[string]interface{})["announcementTitle"] = *g.AnnouncementTitle
+	if ag.AnnouncementTitle != nil && *ag.AnnouncementTitle != "" {
+		attributes["announcementTitle"] = *ag.AnnouncementTitle
 	}
-	if g.AnnouncementMessage != nil && *g.AnnouncementMessage != "" {
-		customJSON["attributes"].(map[string]interface{})["announcementMessage"] = *g.AnnouncementMessage
+	if ag.AnnouncementMessage != nil && *ag.AnnouncementMessage != "" {
+		attributes["announcementMessage"] = *ag.AnnouncementMessage
 	}
-	if g.CertificateStatus != nil {
-		customJSON["attributes"].(map[string]interface{})["certificateStatus"] = *g.CertificateStatus
+	if ag.CertificateStatus != nil {
+		attributes["certificateStatus"] = *ag.CertificateStatus
 	}
 
 	// Marshal the custom JSON

--- a/atlan/assets/persona_client.go
+++ b/atlan/assets/persona_client.go
@@ -1,0 +1,307 @@
+package assets
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/atlanhq/atlan-go/atlan/model/structs"
+)
+
+type Persona structs.Persona
+
+// Creator is used to create a new persona asset in memory.
+func (p *Persona) Creator(name string) {
+	p.TypeName = structs.StringPtr("Persona")
+	p.Name = structs.StringPtr(name)
+}
+
+/*
+	Example Usage :
+	persona := &Persona{}
+	policy, err := persona.CreateMetadataPolicy(
+		"MyPolicy",
+		"persona-guid-1234",
+		atlan.AuthPolicyTypeMetadata,
+		[]atlan.PersonaMetadataAction{
+			atlan.PersonaMetadataActionRead,
+			atlan.PersonaMetadataActionWrite,
+		},
+		"connection-guid-5678",
+		[]string{"resource1", "resource2"},
+
+	)
+*/
+
+// CreateMetadataPolicy creates a new metadata policy for a persona.
+func (p *Persona) CreateMetadataPolicy(
+	name string,
+	personaID string,
+	policyType atlan.AuthPolicyType,
+	actions []atlan.PersonaMetadataAction,
+	connectionQualifiedName string,
+	resources []string) (*AuthPolicy, error) {
+
+	// Convert actions to their string values
+	var policyActions []string
+	for _, action := range actions {
+		policyActions = append(policyActions, action.String())
+	}
+
+	// Create the policy object
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			Name:                    structs.StringPtr(name),
+			ConnectionQualifiedName: &connectionQualifiedName,
+			Referenceable: structs.Referenceable{
+				Guid: &personaID,
+			},
+		},
+		PolicyType:             &policyType,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPersona.String()),
+		PolicyResources:        &resources,
+		PolicyActions:          &policyActions,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryCustom.String()),
+		PolicyServiceName:      structs.StringPtr("atlas"),
+		PolicySubCategory:      structs.StringPtr("metadata"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid:     &personaID,
+					TypeName: structs.StringPtr("Persona"),
+				},
+			},
+		},
+	}
+	return policy, nil
+}
+
+// CreateDataPolicy creates a new data policy for a persona.
+func (p *Persona) CreateDataPolicy(
+	name string,
+	personaID string,
+	policyType atlan.AuthPolicyType,
+	connectionQualifiedName string,
+	resources []string) (*AuthPolicy, error) {
+
+	// Add "entity-type:*" to resources
+	resources = append(resources, "entity-type:*")
+
+	// Define default policy actions
+	policyActions := []string{atlan.DataActionSelect.String()}
+
+	// Create the policy object
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			ConnectionQualifiedName: &connectionQualifiedName,
+			Name:                    &name,
+			Referenceable: structs.Referenceable{
+				Guid: &personaID,
+			},
+		},
+		PolicyType:             &policyType,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPersona.String()),
+		PolicyActions:          &policyActions,
+		PolicyResources:        &resources,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryEntity.String()),
+		PolicyServiceName:      structs.StringPtr("heka"),
+		PolicySubCategory:      structs.StringPtr("data"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid: &personaID,
+				},
+			},
+		},
+	}
+
+	return policy, nil
+}
+
+// CreateGlossaryPolicy creates a new glossary policy for a persona.
+func (p *Persona) CreateGlossaryPolicy(
+	name string,
+	personaID string,
+	policyType atlan.AuthPolicyType,
+	actions []atlan.PersonaGlossaryAction,
+	resources []string) (*AuthPolicy, error) {
+
+	// Convert actions to their string values
+	policyActions := make([]string, len(actions))
+	for i, action := range actions {
+		policyActions[i] = action.String()
+	}
+
+	// Create the policy object
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			Name: &name,
+			Referenceable: structs.Referenceable{
+				Guid: &personaID,
+			},
+		},
+		PolicyType:             &policyType,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPersona.String()),
+		PolicyActions:          &policyActions,
+		PolicyResources:        &resources,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryCustom.String()),
+		PolicyServiceName:      structs.StringPtr("atlas"),
+		PolicySubCategory:      structs.StringPtr("glossary"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid: &personaID,
+				},
+			},
+		},
+	}
+
+	return policy, nil
+}
+
+// CreateDomainPolicy creates a new domain policy for a persona.
+func (p *Persona) CreateDomainPolicy(
+	name string,
+	personaID string,
+	actions []atlan.PersonaDomainAction,
+	resources []string,
+) (*AuthPolicy, error) {
+
+	// Convert actions to their string values
+	policyActions := make([]string, len(actions))
+	for i, action := range actions {
+		policyActions[i] = action.String()
+	}
+
+	// Create the policy object
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			Name: &name,
+			Referenceable: structs.Referenceable{
+				Guid: &personaID,
+			},
+		},
+		PolicyType:             &atlan.AuthPolicyTypeAllow,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPersona.String()),
+		PolicyActions:          &policyActions,
+		PolicyResources:        &resources,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryCustom.String()),
+		PolicyServiceName:      structs.StringPtr("atlas"),
+		PolicySubCategory:      structs.StringPtr("domain"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid: &personaID,
+				},
+			},
+		},
+	}
+
+	return policy, nil
+}
+
+func (p *Persona) Updater(qualifiedName, name string, isEnabled bool) error {
+	// Validate required fields
+	if qualifiedName == "" || name == "" {
+		return fmt.Errorf("missing required fields: qualifiedName and name")
+	}
+	p.QualifiedName = &qualifiedName
+	p.Name = &name
+	p.IsAccessControlEnabled = &isEnabled
+	return nil
+}
+
+func (p *Persona) UnmarshalJSON(data []byte) error {
+	// Define a temporary structure with the expected JSON structure.
+	var temp struct {
+		ReferredEntities map[string]interface{} `json:"referredEntities"`
+		Entity           struct {
+			TypeName               string            `json:"typeName"`
+			AttributesJSON         json.RawMessage   `json:"attributes"`
+			Guid                   string            `json:"guid"`
+			IsIncomplete           bool              `json:"isIncomplete"`
+			Status                 atlan.AtlanStatus `json:"status"`
+			CreatedBy              string            `json:"createdBy"`
+			UpdatedBy              string            `json:"updatedBy"`
+			CreateTime             int64             `json:"createTime"`
+			UpdateTime             int64             `json:"updateTime"`
+			Version                int               `json:"version"`
+			RelationshipAttributes struct {
+				SchemaRegistrySubjects []structs.SchemaRegistrySubject `json:"schemaRegistrySubjects"`
+				McMonitors             []structs.MCMonitor             `json:"mcMonitors"`
+				Terms                  []structs.AtlasGlossaryTerm     `json:"terms"`
+				OutputPortDataProducts []string                        `json:"outputPortDataProducts"`
+				AtlasGlossary          []structs.AtlasGlossary         `json:"AtlasGlossary"`
+				AccessControl          []structs.AccessControl         `json:"AccessControl"`
+				Policies               []structs.AuthPolicy            `json:"policies"`
+			} `json:"relationshipAttributes"`
+		}
+	}
+
+	// Unmarshal the JSON data into the temporary structure.
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	// Unmarshal the attributes JSON into the entity.
+	if err := json.Unmarshal(temp.Entity.AttributesJSON, &p); err != nil {
+		return err
+	}
+
+	// Set the GUID and TypeName.
+	p.Guid = &temp.Entity.Guid
+	p.TypeName = &temp.Entity.TypeName
+
+	return nil
+}
+
+func (p *Persona) MarshalJSON() ([]byte, error) {
+	// Marshal the AccessControl asset into a JSON object.
+
+	// Construct the custom JSON structure
+	customJSON := map[string]interface{}{
+		"typeName": "Persona",
+		"attributes": map[string]interface{}{
+			"name":          p.Name,
+			"qualifiedName": p.Name,
+			//		"displayName":            p.Name,
+			"isAccessControlEnabled": true,
+			// Add other attributes as necessary.
+		},
+	}
+
+	if p.IsAccessControlEnabled != nil {
+		customJSON["attributes"].(map[string]interface{})["isAccessControlEnabled"] = *p.IsAccessControlEnabled
+	}
+
+	if p.QualifiedName != nil && *p.QualifiedName != "" {
+		customJSON["attributes"].(map[string]interface{})["qualifiedName"] = *p.QualifiedName
+	}
+
+	if p.Guid != nil && *p.Guid != "" {
+		customJSON["guid"] = *p.Guid
+	}
+
+	if p.DisplayName != nil && *p.DisplayName != "" {
+		customJSON["attributes"].(map[string]interface{})["displayName"] = *p.DisplayName
+	}
+
+	if p.PersonaUsers != nil {
+		customJSON["attributes"].(map[string]interface{})["personaUsers"] = p.PersonaUsers
+	}
+
+	if p.PersonaGroups != nil {
+		customJSON["attributes"].(map[string]interface{})["personaGroups"] = p.PersonaGroups
+	}
+
+	return json.MarshalIndent(customJSON, "", "  ")
+}
+
+func (p *Persona) ToJSON() ([]byte, error) {
+	// Marshal the Persona object into a JSON object.
+	return json.Marshal(p)
+}
+
+func (p *Persona) FromJSON(data []byte) error {
+	// Unmarshal the JSON data into the Persona object.
+	return json.Unmarshal(data, p)
+}

--- a/atlan/assets/persona_client_test.go
+++ b/atlan/assets/persona_client_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/atlanhq/atlan-go/atlan"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 var PersonaName = atlan.MakeUnique("Persona")
@@ -16,8 +17,11 @@ func TestIntegrationPersona(t *testing.T) {
 	NewContext()
 
 	personaID, personaQualifiedName := testCreatePersona(t)
+	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testRetrievePersona(t, personaID)
+	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testUpdatePersona(t, personaQualifiedName)
+	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testDeletePersona(t, personaID)
 }
 

--- a/atlan/assets/persona_client_test.go
+++ b/atlan/assets/persona_client_test.go
@@ -17,7 +17,7 @@ func TestIntegrationPersona(t *testing.T) {
 	NewContext()
 
 	personaID, personaQualifiedName := testCreatePersona(t)
-	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
+	time.Sleep(5 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testRetrievePersona(t, personaID)
 	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testUpdatePersona(t, personaQualifiedName)

--- a/atlan/assets/persona_client_test.go
+++ b/atlan/assets/persona_client_test.go
@@ -1,0 +1,77 @@
+package assets
+
+import (
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var PersonaName = atlan.MakeUnique("Persona")
+
+func TestIntegrationPersona(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	NewContext()
+
+	personaID, personaQualifiedName := testCreatePersona(t)
+	testRetrievePersona(t, personaID)
+	testUpdatePersona(t, personaQualifiedName)
+	testDeletePersona(t, personaID)
+}
+
+func testCreatePersona(t *testing.T) (string, string) {
+	p := &Persona{}
+	// Create Persona
+	p.Creator(PersonaName)
+	response, err := Save(p)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, response, "fetched persona should not be nil")
+	assert.Equal(t, 1, len(response.MutatedEntities.CREATE), "number of personas created should be 1")
+	assert.Equal(t, 0, len(response.MutatedEntities.UPDATE), "number of personas updated should be 0")
+	assert.Equal(t, 0, len(response.MutatedEntities.DELETE), "number of personas deleted should be 0")
+	assetone := response.MutatedEntities.CREATE[0]
+	assert.NotNil(t, assetone, "persona should not be nil")
+	assert.Equal(t, PersonaName, *assetone.Attributes.Name, "persona name should match")
+	assert.Equal(t, *p.TypeName, assetone.TypeName, "persona type should match")
+
+	return assetone.Guid, *assetone.Attributes.QualifiedName
+}
+
+func testRetrievePersona(t *testing.T, personaID string) {
+	persona, err := GetByGuid[*Persona](personaID)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, persona, "fetched persona should not be nil")
+	assert.Equal(t, PersonaName, *persona.Name, "persona name should match")
+}
+
+func testUpdatePersona(t *testing.T, personaQualifiedName string) {
+	p := &Persona{}
+	Name := "gsdk-test-update"
+	p.Updater(personaQualifiedName, PersonaName, true)
+	p.Name = &Name
+	updateresponse, err := Save(p)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, updateresponse, "fetched persona should not be nil")
+	assert.Equal(t, 1, len(updateresponse.MutatedEntities.UPDATE), "number of personas updated should be 1")
+	assert.Equal(t, *p.Name, *updateresponse.MutatedEntities.UPDATE[0].Attributes.Name, "persona display name should match")
+}
+
+func testDeletePersona(t *testing.T, personaID string) {
+	deleteresponse, err := PurgeByGuid([]string{personaID})
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, deleteresponse, "fetched persona should not be nil")
+	assert.Equal(t, 1, len(deleteresponse.MutatedEntities.DELETE), "number of personas deleted should be 1")
+	assert.Equal(t, personaID, deleteresponse.MutatedEntities.DELETE[0].Guid, "persona guid should match")
+}
+
+// Add tests related to creating policies using Persona when the Managing connections would be implemented by the sdk

--- a/atlan/assets/persona_client_test.go
+++ b/atlan/assets/persona_client_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/atlanhq/atlan-go/atlan"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"time"
 )
 
 var PersonaName = atlan.MakeUnique("Persona")
@@ -17,11 +16,8 @@ func TestIntegrationPersona(t *testing.T) {
 	NewContext()
 
 	personaID, personaQualifiedName := testCreatePersona(t)
-	time.Sleep(5 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testRetrievePersona(t, personaID)
-	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testUpdatePersona(t, personaQualifiedName)
-	time.Sleep(2 * time.Second) // Sleep for 2 seconds in order for changes to reflect in platform
 	testDeletePersona(t, personaID)
 }
 
@@ -37,12 +33,12 @@ func testCreatePersona(t *testing.T) (string, string) {
 	assert.Equal(t, 1, len(response.MutatedEntities.CREATE), "number of personas created should be 1")
 	assert.Equal(t, 0, len(response.MutatedEntities.UPDATE), "number of personas updated should be 0")
 	assert.Equal(t, 0, len(response.MutatedEntities.DELETE), "number of personas deleted should be 0")
-	assetone := response.MutatedEntities.CREATE[0]
-	assert.NotNil(t, assetone, "persona should not be nil")
-	assert.Equal(t, PersonaName, *assetone.Attributes.Name, "persona name should match")
-	assert.Equal(t, *p.TypeName, assetone.TypeName, "persona type should match")
+	CreatedPersona := response.MutatedEntities.CREATE[0]
+	assert.NotNil(t, CreatedPersona, "persona should not be nil")
+	assert.Equal(t, PersonaName, *CreatedPersona.Attributes.Name, "persona name should match")
+	assert.Equal(t, *p.TypeName, CreatedPersona.TypeName, "persona type should match")
 
-	return assetone.Guid, *assetone.Attributes.QualifiedName
+	return CreatedPersona.Guid, *CreatedPersona.Attributes.QualifiedName
 }
 
 func testRetrievePersona(t *testing.T, personaID string) {

--- a/atlan/enums.go
+++ b/atlan/enums.go
@@ -2958,3 +2958,210 @@ func (c *AuthPolicyType) UnmarshalJSON(data []byte) error {
 func (c AuthPolicyType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Name)
 }
+
+type AuthPolicyCategory struct {
+	Name string
+}
+
+func (a AuthPolicyCategory) String() string {
+	return a.Name
+}
+
+var (
+	AuthPolicyCategoryBootstrap = AuthPolicyCategory{"bootstrap"}
+	AuthPolicyCategoryPersona   = AuthPolicyCategory{"persona"}
+	AuthPolicyCategoryPurpose   = AuthPolicyCategory{"purpose"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a AuthPolicyCategory from JSON.
+func (c *AuthPolicyCategory) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+
+	case "bootstrap":
+		*c = AuthPolicyCategoryBootstrap
+
+	case "persona":
+		*c = AuthPolicyCategoryPersona
+
+	case "purpose":
+		*c = AuthPolicyCategoryPurpose
+	default:
+		*c = AuthPolicyCategory{Name: name}
+	}
+
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a AuthPolicyCategory to JSON.
+func (c AuthPolicyCategory) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Name)
+}
+
+type AuthPolicyResourceCategory struct {
+	Name string
+}
+
+func (a AuthPolicyResourceCategory) String() string {
+	return a.Name
+}
+
+var (
+	AuthPolicyResourceCategoryEntity       = AuthPolicyResourceCategory{"ENTITY"}
+	AuthPolicyResourceCategoryRelationship = AuthPolicyResourceCategory{"RELATIONSHIP"}
+	AuthPolicyResourceCategoryTag          = AuthPolicyResourceCategory{"TAG"}
+	AuthPolicyResourceCategoryCustom       = AuthPolicyResourceCategory{"CUSTOM"}
+	AuthPolicyResourceCategoryTypedefs     = AuthPolicyResourceCategory{"TYPEDEFS"}
+	AuthPolicyResourceCategoryAdmin        = AuthPolicyResourceCategory{"ADMIN"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a AuthPolicyResourceCategory from JSON.
+func (c *AuthPolicyResourceCategory) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+
+	case "ENTITY":
+		*c = AuthPolicyResourceCategoryEntity
+
+	case "RELATIONSHIP":
+		*c = AuthPolicyResourceCategoryRelationship
+
+	case "TAG":
+		*c = AuthPolicyResourceCategoryTag
+
+	case "CUSTOM":
+		*c = AuthPolicyResourceCategoryCustom
+
+	case "TYPEDEFS":
+		*c = AuthPolicyResourceCategoryTypedefs
+
+	case "ADMIN":
+		*c = AuthPolicyResourceCategoryAdmin
+	default:
+		*c = AuthPolicyResourceCategory{Name: name}
+	}
+
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a AuthPolicyResourceCategory to JSON.
+func (c AuthPolicyResourceCategory) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Name)
+}
+
+type DataAction struct {
+	Name string
+}
+
+func (a DataAction) String() string {
+	return a.Name
+}
+
+var (
+	DataActionSelect = DataAction{"select"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a DataAction from JSON.
+func (c *DataAction) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+
+	case "select":
+		*c = DataActionSelect
+	default:
+		*c = DataAction{Name: name}
+	}
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a DataAction to JSON.
+func (c DataAction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Name)
+}
+
+type PersonaDomainAction struct {
+	Name string
+}
+
+func (a PersonaDomainAction) String() string {
+	return a.Name
+}
+
+var (
+	PersonaDomainActionCreate                        = PersonaDomainAction{"persona-domain-create"}
+	PersonaDomainActionRead                          = PersonaDomainAction{"persona-domain-read"}
+	PersonaDomainActionUpdate                        = PersonaDomainAction{"persona-domain-update"}
+	PersonaDomainActionDelete                        = PersonaDomainAction{"persona-domain-delete"}
+	PersonaDomainActionCreateSubdomain               = PersonaDomainAction{"persona-domain-sub-domain-create"}
+	PersonaDomainActionReadSubdomain                 = PersonaDomainAction{"persona-domain-sub-domain-read"}
+	PersonaDomainActionUpdateSubdomain               = PersonaDomainAction{"persona-domain-sub-domain-update"}
+	PersonaDomainActionDeleteSubdomain               = PersonaDomainAction{"persona-domain-sub-domain-delete"}
+	PersonaDomainActionCreateProducts                = PersonaDomainAction{"persona-domain-product-create"}
+	PersonaDomainActionReadProducts                  = PersonaDomainAction{"persona-domain-product-read"}
+	PersonaDomainActionUpdateProducts                = PersonaDomainAction{"persona-domain-product-update"}
+	PersonaDomainActionDeleteProducts                = PersonaDomainAction{"persona-domain-product-delete"}
+	PersonaDomainActionUpdateDomainCustomMetadata    = PersonaDomainAction{"persona-domain-business-update-metadata"}
+	PersonaDomainActionUpdateSubdomainCustomMetadata = PersonaDomainAction{"persona-domain-sub-domain-business-update-metadata"}
+	PersonaDomainActionUpdateProductCustomMetadata   = PersonaDomainAction{"persona-domain-product-business-update-metadata"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a PersonaDomainAction from JSON.
+func (c *PersonaDomainAction) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+	case "persona-domain-create":
+		*c = PersonaDomainActionCreate
+	case "persona-domain-read":
+		*c = PersonaDomainActionRead
+	case "persona-domain-update":
+		*c = PersonaDomainActionUpdate
+	case "persona-domain-delete":
+		*c = PersonaDomainActionDelete
+	case "persona-domain-sub-domain-create":
+		*c = PersonaDomainActionCreateSubdomain
+	case "persona-domain-sub-domain-read":
+		*c = PersonaDomainActionReadSubdomain
+	case "persona-domain-sub-domain-update":
+		*c = PersonaDomainActionUpdateSubdomain
+	case "persona-domain-sub-domain-delete":
+		*c = PersonaDomainActionDeleteSubdomain
+	case "persona-domain-product-create":
+		*c = PersonaDomainActionCreateProducts
+	case "persona-domain-product-read":
+		*c = PersonaDomainActionReadProducts
+	case "persona-domain-product-update":
+		*c = PersonaDomainActionUpdateProducts
+	case "persona-domain-product-delete":
+		*c = PersonaDomainActionDeleteProducts
+	case "persona-domain-business-update-metadata":
+		*c = PersonaDomainActionUpdateDomainCustomMetadata
+	case "persona-domain-sub-domain-business-update-metadata":
+		*c = PersonaDomainActionUpdateSubdomainCustomMetadata
+	case "persona-domain-product-business-update-metadata":
+		*c = PersonaDomainActionUpdateProductCustomMetadata
+	default:
+		*c = PersonaDomainAction{Name: name}
+	}
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a PersonaDomainAction to JSON.
+func (c PersonaDomainAction) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Name)
+}

--- a/atlan/enums.go
+++ b/atlan/enums.go
@@ -2903,3 +2903,58 @@ func (c *CertificateStatus) UnmarshalJSON(data []byte) error {
 func (c CertificateStatus) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Name)
 }
+
+type AuthPolicyType struct {
+	Name string
+}
+
+func (a AuthPolicyType) String() string {
+	return a.Name
+}
+
+var (
+	AuthPolicyTypeAllow           = AuthPolicyType{"allow"}
+	AuthPolicyTypeDeny            = AuthPolicyType{"deny"}
+	AuthPolicyTypeAllowexceptions = AuthPolicyType{"allowExceptions"}
+	AuthPolicyTypeDenyexceptions  = AuthPolicyType{"denyExceptions"}
+	AuthPolicyTypeDatamask        = AuthPolicyType{"dataMask"}
+	AuthPolicyTypeRowfilter       = AuthPolicyType{"rowFilter"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a AuthPolicyType from JSON.
+func (c *AuthPolicyType) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+
+	case "allow":
+		*c = AuthPolicyTypeAllow
+
+	case "deny":
+		*c = AuthPolicyTypeDeny
+
+	case "allowExceptions":
+		*c = AuthPolicyTypeAllowexceptions
+
+	case "denyExceptions":
+		*c = AuthPolicyTypeDenyexceptions
+
+	case "dataMask":
+		*c = AuthPolicyTypeDatamask
+
+	case "rowFilter":
+		*c = AuthPolicyTypeRowfilter
+	default:
+		*c = AuthPolicyType{Name: name}
+	}
+
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a AuthPolicyType to JSON.
+func (c AuthPolicyType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Name)
+}

--- a/atlan/enums.go
+++ b/atlan/enums.go
@@ -3165,3 +3165,45 @@ func (c *PersonaDomainAction) UnmarshalJSON(data []byte) error {
 func (c PersonaDomainAction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.Name)
 }
+
+type AssetFilterGroup struct {
+	Name string
+}
+
+func (a AssetFilterGroup) String() string {
+	return a.Name
+}
+
+var (
+	AssetFilterGroupTerms       = AssetFilterGroup{"terms"}
+	AssetFilterGroupTags        = AssetFilterGroup{"__traitNames"}
+	AssetFilterGroupOwners      = AssetFilterGroup{"owners"}
+	AssetFilterGroupUsage       = AssetFilterGroup{"usage"}
+	AssetFilterGroupProperties  = AssetFilterGroup{"properties"}
+	AssetFilterGroupCertificate = AssetFilterGroup{"certificateStatus"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a AssetFilterGroup from JSON.
+func (c *AssetFilterGroup) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+	switch name {
+	case "terms":
+		*c = AssetFilterGroupTerms
+	case "__traitNames":
+		*c = AssetFilterGroupTags
+	case "owners":
+		*c = AssetFilterGroupOwners
+	case "usage":
+		*c = AssetFilterGroupUsage
+	case "properties":
+		*c = AssetFilterGroupProperties
+	case "certificateStatus":
+		*c = AssetFilterGroupCertificate
+	default:
+		*c = AssetFilterGroup{Name: name}
+	}
+	return nil
+}

--- a/atlan/model/search.go
+++ b/atlan/model/search.go
@@ -538,6 +538,9 @@ type SearchAssets struct {
 	structs.Asset
 	structs.Table
 	structs.Column
+	structs.AuthPolicy
+	structs.Persona
+	structs.AccessControl
 	QualifiedName       *string           `json:"qualifiedName,omitempty"`
 	Name                *string           `json:"name,omitempty"`
 	SearchAttributes    *SearchAttributes `json:"Attributes,omitempty"`
@@ -619,6 +622,40 @@ type SearchAttributes struct {
 	TablePartition                 *structs.TablePartition            `json:"tablePartition,omitempty"`
 	MaxLength                      *int                               `json:"maxLength,omitempty"`
 
+	// Access Control Attributes
+	IsAccessControlEnabled  *bool                               `json:"isAccessControlEnabled,omitempty"`
+	DenyCustomMetadataGuids *[]string                           `json:"denyCustomMetadataGuids,omitempty"`
+	DenyAssetTabs           *[]string                           `json:"denyAssetTabs,omitempty"`
+	DenyAssetFilters        *[]string                           `json:"denyAssetFilters,omitempty"`
+	ChannelLink             *string                             `json:"channelLink,omitempty"`
+	DenyAssetTypes          *[]string                           `json:"denyAssetTypes,omitempty"`
+	DenyNavigationPages     *[]string                           `json:"denyNavigationPages,omitempty"`
+	DefaultNavigation       *string                             `json:"defaultNavigation,omitempty"`
+	DisplayPreferences      *[]string                           `json:"displayPreferences,omitempty"`
+	Policies                *[]structs.AuthPolicy               `json:"policies,omitempty"` // Relationship
+	PolicyType              *atlan.AuthPolicyType               `json:"policyType,omitempty"`
+	PolicyServiceName       *string                             `json:"policyServiceName,omitempty"`
+	PolicyCategory          *string                             `json:"policyCategory,omitempty"`
+	PolicySubCategory       *string                             `json:"policySubCategory,omitempty"`
+	PolicyUsers             *[]string                           `json:"policyUsers,omitempty"`
+	PolicyGroups            *[]string                           `json:"policyGroups,omitempty"`
+	PolicyRoles             *[]string                           `json:"policyRoles,omitempty"`
+	PolicyActions           *[]string                           `json:"policyActions,omitempty"`
+	PolicyResources         *[]string                           `json:"policyResources,omitempty"`
+	PolicyResourceCategory  *string                             `json:"policyResourceCategory,omitempty"`
+	PolicyPriority          *int                                `json:"policyPriority,omitempty"`
+	IsPolicyEnabled         *bool                               `json:"isPolicyEnabled,omitempty"`
+	PolicyMaskType          *string                             `json:"policyMaskType,omitempty"`
+	PolicyValiditySchedule  *[]atlan.AuthPolicyValiditySchedule `json:"policyValiditySchedule,omitempty"`
+	PolicyResourceSignature *string                             `json:"policyResourceSignature,omitempty"`
+	PolicyDelegateAdmin     *bool                               `json:"policyDelegateAdmin,omitempty"`
+	PolicyConditions        *[]atlan.AuthPolicyCondition        `json:"policyConditions,omitempty"`
+	AccessControl           *structs.AccessControl              `json:"accessControl,omitempty"` // Relationship
+	PersonaGroups           *[]string                           `json:"personaGroups,omitempty"`
+	PersonaUsers            *[]string                           `json:"personaUsers,omitempty"`
+	RoleId                  *string                             `json:"roleId,omitempty"`
+
+	// Common Attributes
 	QualifiedName            *string                  `json:"qualifiedName,omitempty"`
 	Name                     *string                  `json:"name,omitempty"`
 	UserDescription          *string                  `json:"userDescription,omitempty"`
@@ -666,39 +703,134 @@ func (sa *SearchAssets) MarshalJSON() ([]byte, error) {
 		},
 	}
 
+	attributes := customJSON["attributes"].(map[string]interface{})
+
 	if sa.Guid != nil && *sa.Asset.Guid != "" {
 		customJSON["guid"] = *sa.Guid
 	}
 
 	if sa.Asset.DisplayName != nil && *sa.Asset.DisplayName != "" {
-		customJSON["attributes"].(map[string]interface{})["DisplayText"] = *sa.Asset.DisplayName
+		attributes["DisplayText"] = *sa.Asset.DisplayName
 	}
 
 	if sa.Asset.Description != nil && *sa.Asset.Description != "" {
-		customJSON["attributes"].(map[string]interface{})["description"] = *sa.Asset.Description
+		attributes["description"] = *sa.Asset.Description
 	}
 
 	if sa.Table.SchemaName != nil && *sa.Table.SchemaName != "" {
-		customJSON["attributes"].(map[string]interface{})["schemaName"] = *sa.Table.SchemaName
+		attributes["schemaName"] = *sa.Table.SchemaName
 	}
 
 	if sa.Table.DatabaseName != nil && *sa.Table.DatabaseName != "" {
-		customJSON["attributes"].(map[string]interface{})["databaseName"] = *sa.Table.DatabaseName
+		attributes["databaseName"] = *sa.Table.DatabaseName
 	}
 
 	if sa.Table.DatabaseQualifiedName != nil && *sa.Table.DatabaseQualifiedName != "" {
-		customJSON["attributes"].(map[string]interface{})["databaseQualifiedName"] = *sa.Table.DatabaseQualifiedName
+		attributes["databaseQualifiedName"] = *sa.Table.DatabaseQualifiedName
 	}
 
 	if sa.Table.ConnectionQualifiedName != nil && *sa.Table.ConnectionQualifiedName != "" {
-		customJSON["attributes"].(map[string]interface{})["connectionQualifiedName"] = *sa.Table.ConnectionQualifiedName
+		attributes["connectionQualifiedName"] = *sa.Table.ConnectionQualifiedName
 	}
 
 	if sa.Asset.CertificateStatus != nil {
-		customJSON["attributes"].(map[string]interface{})["certificateStatus"] = *sa.Asset.CertificateStatus
+		attributes["certificateStatus"] = *sa.Asset.CertificateStatus
 	}
 
 	// Requires Model Generator for generating other assets
+
+	// Add access control attributes
+
+	if sa.IsAccessControlEnabled != nil {
+		attributes["isAccessControlEnabled"] = *sa.IsAccessControlEnabled
+	}
+	if sa.DenyCustomMetadataGuids != nil {
+		attributes["denyCustomMetadataGuids"] = *sa.DenyCustomMetadataGuids
+	}
+	if sa.DenyAssetTabs != nil {
+		attributes["denyAssetTabs"] = *sa.DenyAssetTabs
+	}
+	if sa.DenyAssetFilters != nil {
+		attributes["denyAssetFilters"] = *sa.DenyAssetFilters
+	}
+	if sa.ChannelLink != nil {
+		attributes["channelLink"] = *sa.ChannelLink
+	}
+	if sa.DenyAssetTypes != nil {
+		attributes["denyAssetTypes"] = *sa.DenyAssetTypes
+	}
+	if sa.DenyNavigationPages != nil {
+		attributes["denyNavigationPages"] = *sa.DenyNavigationPages
+	}
+	if sa.DefaultNavigation != nil {
+		attributes["defaultNavigation"] = *sa.DefaultNavigation
+	}
+	if sa.DisplayPreferences != nil {
+		attributes["displayPreferences"] = *sa.DisplayPreferences
+	}
+	if sa.Policies != nil {
+		attributes["policies"] = sa.Policies // Assuming proper JSON marshalling of structs.AuthPolicy
+	}
+	if sa.PolicyType != nil {
+		attributes["policyType"] = *sa.PolicyType
+	}
+	if sa.PolicyServiceName != nil {
+		attributes["policyServiceName"] = *sa.PolicyServiceName
+	}
+	if sa.PolicyCategory != nil {
+		attributes["policyCategory"] = *sa.PolicyCategory
+	}
+	if sa.PolicySubCategory != nil {
+		attributes["policySubCategory"] = *sa.PolicySubCategory
+	}
+	if sa.PolicyUsers != nil {
+		attributes["policyUsers"] = *sa.PolicyUsers
+	}
+	if sa.PolicyGroups != nil {
+		attributes["policyGroups"] = *sa.PolicyGroups
+	}
+	if sa.PolicyRoles != nil {
+		attributes["policyRoles"] = *sa.PolicyRoles
+	}
+	if sa.PolicyActions != nil {
+		attributes["policyActions"] = *sa.PolicyActions
+	}
+	if sa.PolicyResources != nil {
+		attributes["policyResources"] = *sa.PolicyResources
+	}
+	if sa.PolicyResourceCategory != nil {
+		attributes["policyResourceCategory"] = *sa.PolicyResourceCategory
+	}
+	if sa.PolicyPriority != nil {
+		attributes["policyPriority"] = *sa.PolicyPriority
+	}
+	if sa.IsPolicyEnabled != nil {
+		attributes["isPolicyEnabled"] = *sa.IsPolicyEnabled
+	}
+	if sa.PolicyMaskType != nil {
+		attributes["policyMaskType"] = *sa.PolicyMaskType
+	}
+	if sa.PolicyValiditySchedule != nil {
+		attributes["policyValiditySchedule"] = sa.PolicyValiditySchedule
+	}
+	if sa.PolicyResourceSignature != nil {
+		attributes["policyResourceSignature"] = *sa.PolicyResourceSignature
+	}
+	if sa.PolicyDelegateAdmin != nil {
+		attributes["policyDelegateAdmin"] = *sa.PolicyDelegateAdmin
+	}
+	if sa.PolicyConditions != nil {
+		attributes["policyConditions"] = sa.PolicyConditions
+	}
+	if sa.PersonaGroups != nil {
+		attributes["personaGroups"] = *sa.PersonaGroups
+	}
+	if sa.PersonaUsers != nil {
+		attributes["personaUsers"] = *sa.PersonaUsers
+	}
+	if sa.RoleId != nil {
+		attributes["roleId"] = *sa.RoleId
+	}
 
 	// Marshal the custom JSON
 	return json.MarshalIndent(customJSON, "", "  ")
@@ -710,6 +842,9 @@ func (sa *SearchAssets) UnmarshalJSON(data []byte) error {
 		structs.Asset
 		structs.Table
 		structs.Column
+		structs.AuthPolicy
+		structs.AccessControl
+		structs.Persona
 		QualifiedName       *string           `json:"qualifiedName,omitempty"`
 		Name                *string           `json:"name,omitempty"`
 		SearchAttributes    *SearchAttributes `json:"attributes,omitempty"`
@@ -821,6 +956,38 @@ func (sa *SearchAssets) UnmarshalJSON(data []byte) error {
 		sa.ForeignKeyFrom = aux.SearchAttributes.ForeignKeyFrom
 		sa.DbtMetrics = aux.SearchAttributes.DbtMetrics
 		sa.TablePartition = aux.SearchAttributes.TablePartition
+
+		// Access Control Attributes
+		sa.IsAccessControlEnabled = aux.SearchAttributes.IsAccessControlEnabled
+		sa.DenyCustomMetadataGuids = aux.SearchAttributes.DenyCustomMetadataGuids
+		sa.DenyAssetTabs = aux.SearchAttributes.DenyAssetTabs
+		sa.DenyAssetFilters = aux.SearchAttributes.DenyAssetFilters
+		sa.ChannelLink = aux.SearchAttributes.ChannelLink
+		sa.DenyAssetTypes = aux.SearchAttributes.DenyAssetTypes
+		sa.DenyNavigationPages = aux.SearchAttributes.DenyNavigationPages
+		sa.DefaultNavigation = aux.SearchAttributes.DefaultNavigation
+		sa.DisplayPreferences = aux.SearchAttributes.DisplayPreferences
+		sa.Policies = aux.SearchAttributes.Policies
+		sa.PolicyType = aux.SearchAttributes.PolicyType
+		sa.PolicyServiceName = aux.SearchAttributes.PolicyServiceName
+		sa.PolicyCategory = aux.SearchAttributes.PolicyCategory
+		sa.PolicySubCategory = aux.SearchAttributes.PolicySubCategory
+		sa.PolicyUsers = aux.SearchAttributes.PolicyUsers
+		sa.PolicyGroups = aux.SearchAttributes.PolicyGroups
+		sa.PolicyRoles = aux.SearchAttributes.PolicyRoles
+		sa.PolicyActions = aux.SearchAttributes.PolicyActions
+		sa.PolicyResources = aux.SearchAttributes.PolicyResources
+		sa.PolicyResourceCategory = aux.SearchAttributes.PolicyResourceCategory
+		sa.PolicyPriority = aux.SearchAttributes.PolicyPriority
+		sa.IsPolicyEnabled = aux.SearchAttributes.IsPolicyEnabled
+		sa.PolicyMaskType = aux.SearchAttributes.PolicyMaskType
+		sa.PolicyValiditySchedule = aux.SearchAttributes.PolicyValiditySchedule
+		sa.PolicyResourceSignature = aux.SearchAttributes.PolicyResourceSignature
+		sa.PolicyDelegateAdmin = aux.SearchAttributes.PolicyDelegateAdmin
+		sa.PolicyConditions = aux.SearchAttributes.PolicyConditions
+		sa.PersonaGroups = aux.SearchAttributes.PersonaGroups
+		sa.PersonaUsers = aux.SearchAttributes.PersonaUsers
+		sa.RoleId = aux.SearchAttributes.RoleId
 
 		// Populate `rawSearchAttributes` (necessary for setting `SearchAssets.CustomMetadataSets`)
 		// First, unmarshal the data into a `rawSearchAsset` map

--- a/atlan/model/structs/access_control.go
+++ b/atlan/model/structs/access_control.go
@@ -1,0 +1,49 @@
+package structs
+
+import "github.com/atlanhq/atlan-go/atlan"
+
+// AccessControl represents the attributes of the AccessControl asset.
+type AccessControl struct {
+	Asset
+	IsAccessControlEnabled  *bool         `json:"isAccessControlEnabled,omitempty"`
+	DenyCustomMetadataGuids *[]string     `json:"denyCustomMetadataGuids,omitempty"`
+	DenyAssetTabs           *[]string     `json:"denyAssetTabs,omitempty"`
+	DenyAssetFilters        *[]string     `json:"denyAssetFilters,omitempty"`
+	ChannelLink             *string       `json:"channelLink,omitempty"`
+	DenyAssetTypes          *[]string     `json:"denyAssetTypes,omitempty"`
+	DenyNavigationPages     *[]string     `json:"denyNavigationPages,omitempty"`
+	DefaultNavigation       *string       `json:"defaultNavigation,omitempty"`
+	DisplayPreferences      *[]string     `json:"displayPreferences,omitempty"`
+	Policies                *[]AuthPolicy `json:"policies,omitempty"` // Relationship
+}
+
+// AuthPolicy represents a policy with various attributes.
+type AuthPolicy struct {
+	Asset
+	PolicyType              *atlan.AuthPolicyType               `json:"policyType,omitempty"`
+	PolicyServiceName       *string                             `json:"policyServiceName,omitempty"`
+	PolicyCategory          *string                             `json:"policyCategory,omitempty"`
+	PolicySubCategory       *string                             `json:"policySubCategory,omitempty"`
+	PolicyUsers             *[]string                           `json:"policyUsers,omitempty"`
+	PolicyGroups            *[]string                           `json:"policyGroups,omitempty"`
+	PolicyRoles             *[]string                           `json:"policyRoles,omitempty"`
+	PolicyActions           *[]string                           `json:"policyActions,omitempty"`
+	PolicyResources         *[]string                           `json:"policyResources,omitempty"`
+	PolicyResourceCategory  *string                             `json:"policyResourceCategory,omitempty"`
+	PolicyPriority          *int                                `json:"policyPriority,omitempty"`
+	IsPolicyEnabled         *bool                               `json:"isPolicyEnabled,omitempty"`
+	PolicyMaskType          *string                             `json:"policyMaskType,omitempty"`
+	PolicyValiditySchedule  *[]atlan.AuthPolicyValiditySchedule `json:"policyValiditySchedule,omitempty"`
+	PolicyResourceSignature *string                             `json:"policyResourceSignature,omitempty"`
+	PolicyDelegateAdmin     *bool                               `json:"policyDelegateAdmin,omitempty"`
+	PolicyConditions        *[]atlan.AuthPolicyCondition        `json:"policyConditions,omitempty"`
+	AccessControl           *AccessControl                      `json:"accessControl,omitempty"` // Relationship
+}
+
+// Persona represents the attributes of the Persona asset.
+type Persona struct {
+	AccessControl
+	PersonaGroups *[]string `json:"personaGroups,omitempty"`
+	PersonaUsers  *[]string `json:"personaUsers,omitempty"`
+	RoleId        *string   `json:"roleId,omitempty"`
+}

--- a/atlan/model/structs/access_control.go
+++ b/atlan/model/structs/access_control.go
@@ -20,6 +20,9 @@ type AccessControl struct {
 // AuthPolicy represents a policy with various attributes.
 type AuthPolicy struct {
 	Asset
+	UniqueAttributes struct {
+		QualifiedName *string `json:"qualifiedName"`
+	} `json:"uniqueAttributes"`
 	PolicyType              *atlan.AuthPolicyType               `json:"policyType,omitempty"`
 	PolicyServiceName       *string                             `json:"policyServiceName,omitempty"`
 	PolicyCategory          *string                             `json:"policyCategory,omitempty"`

--- a/atlan/structs.go
+++ b/atlan/structs.go
@@ -1,0 +1,18 @@
+package atlan
+
+// AuthPolicyValiditySchedule: Validity schedule struct for policy
+
+// AuthPolicyValiditySchedule represents the struct for AuthPolicyValiditySchedule.
+type AuthPolicyValiditySchedule struct {
+	Policyvalidityschedulestarttime *string `json:"policyvalidityschedulestarttime,omitempty"`
+	Policyvalidityscheduleendtime   *string `json:"policyvalidityscheduleendtime,omitempty"`
+	Policyvalidityscheduletimezone  *string `json:"policyvalidityscheduletimezone,omitempty"`
+}
+
+// AuthPolicyCondition: Policy condition schedule struct
+
+// AuthPolicyCondition represents the struct for AuthPolicyCondition.
+type AuthPolicyCondition struct {
+	Policyconditiontype   *string   `json:"policyconditiontype,omitempty"`
+	Policyconditionvalues []*string `json:"policyconditionvalues,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"github.com/atlanhq/atlan-go/atlan"
 	_ "github.com/atlanhq/atlan-go/atlan"
 	"github.com/atlanhq/atlan-go/atlan/assets"
 	_ "github.com/atlanhq/atlan-go/atlan/model/structs"
-	"log"
 )
 
 func main() {
@@ -14,54 +11,169 @@ func main() {
 	ctx := assets.NewContext()
 	ctx.EnableLogging("debug")
 
-	schemaQualifiedName := "default/snowflake/1731535899/ANALYTICS/WIDE_WORLD_IMPORTERS"
-
-	batch := assets.NewBatch(ctx, 20, true, atlan.IGNORE, true)
-
-	response, _ := assets.NewFluentSearch().
-		ActiveAssets().
-		PageSizes(100).
-		Where(ctx.Table.QUALIFIED_NAME.StartsWith(schemaQualifiedName, nil)).
-		//Where(ctx.Table.CERTIFICATE_STATUS.Eq("Verified")).
-		//AssetType("Table").
-		AssetTypes([]string{"Table"}).
-		//WhereNot(ctx.Table.CERTIFICATE_STATUS.HasAnyValue()).
-		IncludeOnResults(assets.DESCRIPTION, assets.CERTIFICATE_STATUS, assets.OWNER_USERS).
-		Execute()
-
-	fmt.Println(*response[0].Entities[0].Name)
-
-	// Process each asset in the search results
-	for _, asset := range response[0].Entities {
-
-		Description := "This is Test 5"
-		//Name := "Test4"
-		// Trim to required attributes
-		trimmedAsset, err := assets.TrimToRequired(asset)
+	/*
+		// Allow access to domain
+		Persona := &assets.Persona{}
+		domain, _ := Persona.CreateDomainPolicy(
+			"Allow access to domain",
+			"55226625-0b82-4705-8095-4a7d3f0c228d",
+			[]atlan.PersonaDomainAction{atlan.PersonaDomainActionRead, atlan.PersonaDomainActionReadSubdomain, atlan.PersonaDomainActionReadProducts},
+			[]string{"entity:default/domain/marketing"},
+		)
+		response, err := assets.Save(domain)
 		if err != nil {
-			fmt.Printf("Error trimming asset: %v\n", err)
-			continue
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
 		}
 
-		trimmedAsset.Description = &Description
-		//trimmedAsset.Name = &Name
-		//assets.Save(trimmedAsset)
-		// Add the trimmed asset to the batch
-		err = batch.Add(trimmedAsset)
+	*/
+	/*
+		// Add a glossary policy
+		Persona := &assets.Persona{}
+		glossary, _ := Persona.CreateGlossaryPolicy(
+			"All glossaries",
+			"55226625-0b82-4705-8095-4a7d3f0c228d",
+			atlan.AuthPolicyTypeAllow,
+			[]atlan.PersonaGlossaryAction{atlan.PersonaGlossaryActionCreate, atlan.PersonaGlossaryActionUpdate},
+			[]string{"entity:OW0lMXZKyj4VfCsRxK3nr"},
+		)
+		response, err := assets.Save(glossary)
 		if err != nil {
-			log.Printf("Failed to add asset to batch: %v", err)
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+
 		}
-		batch.Flush()
 
-	}
+	*/
+	/*
+		// Create data policy
+		Persona := &assets.Persona{}
+		data, _ := Persona.CreateDataPolicy(
+			"Allow access to data",
+			"55226625-0b82-4705-8095-4a7d3f0c228d",
+			atlan.AuthPolicyTypeAllow,
+			"default/app/1732538219",
+			[]string{"entity:default/app/1732538219"},
+		)
+		response, err := assets.Save(data)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
 
-	for _, asset := range batch.Updated() {
-		fmt.Println(asset)
-	}
+		}
 
-	for _, asset := range batch.Created() {
-		fmt.Println(asset)
-	}
+	*/
+	/*
+		// Create Metadata Policy
+		Persona := &assets.Persona{}
+		metadata, _ := Persona.CreateMetadataPolicy(
+			"Simple read access",
+			"55226625-0b82-4705-8095-4a7d3f0c228d",
+			atlan.AuthPolicyTypeAllow,
+			[]atlan.PersonaMetadataAction{atlan.PersonaMetadataActionRead},
+			"default/app/1732538219",
+			[]string{"entity:default/app/1732538219"},
+		)
+		response, err := assets.Save(metadata)
+		if err != nil {
+			fmt.Println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+
+	*/
+	/*
+		// Add subjects to persona
+
+		toUpdate := &assets.Persona{}
+		toUpdate.Updater("default/Lnwt6yWFzPfbH95MXauMWR", "Test Persona", true)
+		toUpdate.PersonaGroups = &[]string{"group1", "group2"}
+		toUpdate.PersonaUsers = &[]string{"jsmith", "jdoe"}
+		response, err := assets.Save(toUpdate)
+		if err != nil {
+			fmt.Println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.UPDATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+
+
+	*/
+	/*
+		// Activate or Deactivate a Persona
+		toUpdate := &assets.Persona{}
+		toUpdate.Updater("default/Lnwt6yWFzPfbH95MXauMWR", "Test Persona", true)
+		response, err := assets.Save(toUpdate)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.UPDATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+
+	*/
+	/*
+		// Delete a Persona
+		assets.PurgeByGuid([]string{"5ffb7d15-4435-4f5c-8bb1-6e109ea091c2"})
+
+
+	*/
+	/*
+		// Updater on Persona
+			Persona := &assets.Persona{}
+
+			toUpdate, err := Persona.Updater("default/jtKc6jzvE4UM8yT5uuC3FX", "Test Persona", true)
+			if err != nil {
+				return
+			}
+			DisplayName := "Test Persona Modified"
+			toUpdate.Name = &DisplayName
+			response, err := assets.Save(toUpdate)
+			if err != nil {
+				println("Error:", err)
+			} else {
+				for _, entity := range response.MutatedEntities.UPDATE {
+					println("Response:", entity)
+					println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+				}
+			}
+
+	*/
+	/*
+		// Creator on Persona
+		toCreate := &assets.Persona{}
+
+		toCreate.Creator("Test Persona")
+		response, err := assets.Save(toCreate)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+
+	*/
 
 	/*
 		ctx := assets.NewContext()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,111 @@ func main() {
 	ctx.EnableLogging("debug")
 
 	/*
+		// Get Persona by Guid
+	
+			response, atlanErr := assets.GetByGuid[*assets.Persona]("6f04ac74-d6b8-4b5e-8c1b-2347f9e55414")
+			if atlanErr != nil {
+				fmt.Println("Error:", atlanErr)
+			} else {
+				fmt.Println("RoleID:", *response.RoleId)
+				fmt.Println("Users:", *response.PersonaUsers)
+				fmt.Println("Groups:", *response.PersonaGroups)
+				fmt.Println("DenyAssetFilters:", *response.DenyAssetFilters)
+				//firstPolicy := (*response.Policies)[0]
+				fmt.Println("Policies", (*response.Policies)[0].DisplayName)
+				//		fmt.Println("RoleID:", *response.Policies)
+
+			}
+
+
+	*/
+	/*
+		// Personalize Persona
+
+		toUpdate := &assets.Persona{}
+		toUpdate.Updater("default/Lnwt6yWFzPfbH95MXauMWR", "Test Persona", true)
+
+		toUpdate.DenyAssetTabs = &[]string{atlan.AssetSidebarTabLineage.Name, atlan.AssetSidebarTabRelations.Name, atlan.AssetSidebarTabQueries.Name}
+		toUpdate.DenyAssetTypes = &[]string{"Table", "Column"}
+		toUpdate.DenyAssetFilters = &[]string{atlan.AssetFilterGroupTags.Name, atlan.AssetFilterGroupOwners.Name, atlan.AssetFilterGroupCertificate.Name}
+		toUpdate.DenyCustomMetadataGuids = &[]string{"default/7b4b4b4b-4b4b-4b4b-4b4b-4b4b4b4b4b4b"}
+
+		response, atlanErr := assets.Save(toUpdate)
+		if atlanErr != nil {
+			println("Error:", atlanErr)
+		} else {
+			for _, entity := range response.MutatedEntities.UPDATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+
+
+	*/
+	/*
+		// List Policies in a Persona
+		response, atlanErr := assets.NewFluentSearch().
+			PageSizes(20).
+			AssetType("Persona").
+			Where(ctx.Persona.NAME.Eq("Test Persona")).
+			IncludeOnResults("policies").
+			IncludeOnRelations("name").
+			IncludeOnRelations("policyActions").
+			IncludeOnRelations("policyResources").
+			IncludeOnRelations("policyType").
+			Execute()
+
+		if atlanErr != nil {
+			fmt.Println("Error:", atlanErr)
+		}
+
+		for _, entity := range response[0].Entities {
+			if entity.TypeName != nil && *entity.TypeName == "Persona" {
+				fmt.Println("Persona Found: Name:", *entity.Name, "QualifiedName:", *entity.QualifiedName)
+				for _, policy := range *entity.Policies {
+					fmt.Println("Policy Found: Guid:", *policy.UniqueAttributes.QualifiedName)
+				}
+			}
+		}
+
+	*/
+
+	/*
+		// List Personas
+		response, atlanErr := assets.NewFluentSearch().
+			PageSizes(10).
+			ActiveAssets().
+			AssetType("Persona").
+			Execute()
+
+		if atlanErr != nil {
+			fmt.Println("Error:", atlanErr)
+		}
+		for _, entity := range response[0].Entities {
+			if entity.TypeName != nil && *entity.TypeName == "Persona" {
+				fmt.Printf("Persona Found: Name: %s, QualifiedName: %s\n", *entity.Name, *entity.QualifiedName)
+				// Perform any additional operations with the Persona entity
+				revised, err := assets.TrimToRequired(entity)
+				if err != nil {
+					fmt.Println("Error:", err)
+				}
+				DisplayName := "Test Persona Modified"
+				revised.DisplayName = &DisplayName
+				response, err := assets.Save(revised)
+				if err != nil {
+					fmt.Println("Error:", err)
+				} else {
+					for _, entity := range response.MutatedEntities.UPDATE {
+						println("Response:", entity)
+						println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+					}
+				}
+			}
+		}
+
+	*/
+
+	/*
 		// Allow access to domain
 		Persona := &assets.Persona{}
 		domain, _ := Persona.CreateDomainPolicy(


### PR DESCRIPTION
This PR introduces the following updates:  
- Models for **AccessControl**, **Persona**, and **AuthPolicy**.  
- **Creator** and **Updater** methods for managing Personas.  
- An **Updater** method for Access Control.  
- Functionality to manage policies associated with Personas, including **MetadataPolicy**, **DomainPolicy**, **GlossaryPolicy**, and **DataPolicy**.  
- Resolves FT-467 by implementing a modular approach for marshalling and unmarshalling assets.  
- Improvements to structs and enums to enhance type safety.  
- Integration tests for the newly added features.  
- **Bugfix:** Resolves GUID appending issue in the `GetByGuid()` method.  