### PR TITLE
Bugfix: Add check for adding empty `Personas` and `PersonaQualifiedName` value in request params 

### DIFF
--- a/atlan/assets/token_client.go
+++ b/atlan/assets/token_client.go
@@ -98,6 +98,11 @@ func (tc *TokenClient) Create(displayName, description *string, personas []strin
 		request.ValiditySeconds = validitySeconds
 	}
 
+	if personas == nil {
+		request.Personas = []string{}
+		request.PersonaQualifiedNames = []string{}
+	}
+
 	rawJSON, err := DefaultAtlanClient.CallAPI(&UPSERT_API_TOKEN, nil, request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add empty values in `Personas` and `PersonaQualifiedName` field of request params when the personas is set to `nil`