### PR TITLE
FT-807 : Manage Purposes 

### DIFF
--- a/atlan/assets/auth_policy_client.go
+++ b/atlan/assets/auth_policy_client.go
@@ -123,6 +123,14 @@ func (a *AuthPolicy) MarshalJSON() ([]byte, error) {
 		attributes["connectionQualifiedName"] = *a.ConnectionQualifiedName
 	}
 
+	if a.PolicyGroups != nil && len(*a.PolicyGroups) > 0 {
+		attributes["policyGroups"] = *a.PolicyGroups
+	}
+
+	if a.PolicyUsers != nil && len(*a.PolicyUsers) > 0 {
+		attributes["policyUsers"] = *a.PolicyUsers
+	}
+
 	// Handle nested AccessControl field
 	if a.AccessControl != nil {
 		accessControl := map[string]interface{}{}

--- a/atlan/assets/index_search_client.go
+++ b/atlan/assets/index_search_client.go
@@ -177,6 +177,20 @@ func WithActivePersona(name string) (*model.BoolQuery, error) {
 	}, nil
 }
 
+// WithActivePurpose returns a query for an active purpose by name.
+func WithActivePurpose(name string) (*model.BoolQuery, error) {
+	q1, err := WithState("ACTIVE")
+	if err != nil {
+		return nil, err
+	}
+	q2 := WithTypeName("Purpose")
+	q3 := WithName(name)
+
+	return &model.BoolQuery{
+		Filter: []model.Query{q1, q2, q3},
+	}, nil
+}
+
 // Helper Functions
 
 // WithState returns a query for an entity with a specific state.

--- a/atlan/assets/purpose_client.go
+++ b/atlan/assets/purpose_client.go
@@ -1,0 +1,348 @@
+package assets
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/atlanhq/atlan-go/atlan/model"
+	"github.com/atlanhq/atlan-go/atlan/model/structs"
+)
+
+type Purpose structs.Purpose
+
+// Creator is used to create a new purpose asset in memory.
+func (p *Purpose) Creator(name string, atlanTags []string) error {
+	p.TypeName = structs.StringPtr("Purpose")
+	p.Name = structs.StringPtr(name)
+
+	var atlanTagValues []structs.AtlanTagName
+	for _, tag := range atlanTags {
+		newTag, err := NewAtlanTagName(tag)
+		if err != nil {
+			return fmt.Errorf("failed to create AtlanTagName for %s: %w", tag, err)
+		}
+		atlanTagValues = append(atlanTagValues, *newTag)
+	}
+
+	// Assign the converted tags to PurposeAttributes
+	p.Attributes = &structs.PurposeAttributes{
+		PurposeAtlanTags: &atlanTagValues,
+	}
+	return nil
+}
+
+/*
+	Example Usage:
+	purpose := &Purpose{}
+	policy, err := purpose.CreateMetadataPolicy(
+		"MyPolicy",
+		"purpose-guid-1234",
+		atlan.AuthPolicyTypeMetadata,
+		[]atlan.PurposeMetadataAction{
+			atlan.PurposeMetadataActionRead,
+			atlan.PurposeMetadataActionWrite,
+		},
+		[]string{"group1", "group2"},
+		[]string{"user1", "user2"},
+		true,
+	)
+*/
+
+// CreateMetadataPolicy creates a new metadata policy for a purpose.
+func (p *Purpose) CreateMetadataPolicy(
+	name string,
+	purposeID string,
+	policyType atlan.AuthPolicyType,
+	actions []atlan.PurposeMetadataAction,
+	policyGroups []string,
+	policyUsers []string,
+	allUsers bool,
+) (*AuthPolicy, error) {
+	// Convert actions to their string values
+	var policyActions []string
+	for _, action := range actions {
+		policyActions = append(policyActions, action.String())
+	}
+
+	// Create the policy object
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			Name: &name,
+			Referenceable: structs.Referenceable{
+				Guid: &purposeID,
+			},
+		},
+		PolicyType:             &policyType,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPurpose.String()),
+		PolicyActions:          &policyActions,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryTag.String()),
+		PolicyServiceName:      structs.StringPtr("atlas_tag"),
+		PolicySubCategory:      structs.StringPtr("metadata"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid:     &purposeID,
+					TypeName: structs.StringPtr("Purpose"),
+				},
+			},
+		},
+	}
+
+	// Assign groups and users to the policy
+	if allUsers {
+		policy.PolicyGroups = &[]string{"public"}
+	} else {
+		if len(policyGroups) > 0 {
+			policy.PolicyGroups = &policyGroups
+		}
+		if len(policyUsers) > 0 {
+			policy.PolicyUsers = &policyUsers
+		}
+	}
+
+	if len(*policy.PolicyGroups) == 0 && len(*policy.PolicyUsers) == 0 {
+		return nil, fmt.Errorf("no user or group specified for the policy")
+	}
+
+	return policy, nil
+}
+
+// CreateDataPolicy creates a new data policy for a purpose.
+func (p *Purpose) CreateDataPolicy(
+	name string,
+	purposeID string,
+	policyType atlan.AuthPolicyType,
+	policyGroups []string,
+	policyUsers []string,
+	allUsers bool,
+) (*AuthPolicy, error) {
+	// Default data policy actions
+	policyActions := []string{atlan.DataActionSelect.String()}
+
+	policy := &AuthPolicy{
+		Asset: structs.Asset{
+			Name: &name,
+			Referenceable: structs.Referenceable{
+				Guid: &purposeID,
+			},
+		},
+		PolicyType:             &policyType,
+		PolicyCategory:         structs.StringPtr(atlan.AuthPolicyCategoryPurpose.String()),
+		PolicyActions:          &policyActions,
+		PolicyResourceCategory: structs.StringPtr(atlan.AuthPolicyResourceCategoryTag.String()),
+		PolicyServiceName:      structs.StringPtr("atlas_tag"),
+		PolicySubCategory:      structs.StringPtr("data"),
+		AccessControl: &structs.AccessControl{
+			Asset: structs.Asset{
+				Referenceable: structs.Referenceable{
+					Guid: &purposeID,
+				},
+			},
+		},
+	}
+
+	// Assign groups and users to the policy
+	if allUsers {
+		policy.PolicyGroups = &[]string{"public"}
+	} else {
+		if len(policyGroups) > 0 {
+			policy.PolicyGroups = &policyGroups
+		}
+		if len(policyUsers) > 0 {
+			policy.PolicyUsers = &policyUsers
+		}
+	}
+
+	if len(*policy.PolicyGroups) == 0 && len(*policy.PolicyUsers) == 0 {
+		return nil, fmt.Errorf("no user or group specified for the policy")
+	}
+
+	return policy, nil
+}
+
+func (p *Purpose) Updater(qualifiedName, name string, isEnabled bool) error {
+	if qualifiedName == "" || name == "" {
+		return fmt.Errorf("missing required fields: qualifiedName and name")
+	}
+	p.QualifiedName = &qualifiedName
+	p.Name = &name
+	p.IsAccessControlEnabled = &isEnabled
+	return nil
+}
+
+func FindPurposesByName(name string) (*model.IndexSearchResponse, error) {
+	if name == "" {
+		return nil, fmt.Errorf("name cannot be empty")
+	}
+
+	// Construct the boolean query for active purposes with the given name
+	boolQuery, err := WithActivePurpose(name)
+	if err != nil {
+		return nil, err
+	}
+
+	pageSize := 20
+
+	// Create the search request
+	request := model.IndexSearchRequest{
+		Dsl: model.Dsl{
+			From:           0,
+			Size:           pageSize,
+			Query:          boolQuery.ToJSON(),
+			TrackTotalHits: true,
+		},
+		SuppressLogs:     true,
+		ShowSearchScore:  false,
+		ExcludeMeanings:  false,
+		ExcludeAtlanTags: false,
+	}
+
+	iterator := NewIndexSearchIterator(pageSize, request)
+
+	// Iterate through the pages
+	for iterator.HasMoreResults() {
+		response, err := iterator.NextPage()
+		if err != nil {
+			return nil, fmt.Errorf("error executing search: %v", err)
+		}
+		fmt.Println("Current Page: ", iterator.CurrentPage())
+
+		// Check each entity in the current page
+		for _, entity := range response.Entities {
+			if *entity.TypeName == "Purpose" {
+				return response, nil
+			}
+		}
+	}
+
+	// If no purpose is found, return nil without an error
+	return nil, nil
+}
+
+// NewAtlanTagName creates a new AtlanTagName instance, validating against the cache.
+func NewAtlanTagName(displayText string) (*structs.AtlanTagName, error) {
+	id, _ := GetAtlanTagIDForName(displayText)
+	if id == "" {
+		return nil, fmt.Errorf("%s is not a valid Classification", displayText)
+	}
+	return &structs.AtlanTagName{
+		DisplayText: displayText,
+		ID:          id,
+	}, nil
+}
+
+// UnmarshalJSON unmarshal a Purpose from JSON.
+func (p *Purpose) UnmarshalJSON(data []byte) error {
+	attributes := struct {
+		// Base attributes
+		QualifiedName *string `json:"qualifiedName,omitempty"`
+		Name          *string `json:"name"`
+
+		// Purpose-specific attributes
+		PurposeAtlanTags *[]structs.AtlanTagName `json:"purposeAtlanTags,omitempty"`
+	}{}
+	base, err := UnmarshalBaseEntity(data, &attributes)
+	if err != nil {
+		return err
+	}
+
+	// Map base fields
+	p.Guid = &base.Entity.Guid
+	p.TypeName = &base.Entity.TypeName
+	p.IsIncomplete = &base.Entity.IsIncomplete
+	p.Status = &base.Entity.Status
+	p.CreatedBy = &base.Entity.CreatedBy
+	p.UpdatedBy = &base.Entity.UpdatedBy
+	p.CreateTime = &base.Entity.CreateTime
+	p.UpdateTime = &base.Entity.UpdateTime
+
+	// Map Purpose-specific fields
+	p.QualifiedName = attributes.QualifiedName
+	p.Name = attributes.Name
+	p.Attributes = &structs.PurposeAttributes{
+		PurposeAtlanTags: attributes.PurposeAtlanTags,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a Purpose into JSON.
+func (p *Purpose) MarshalJSON() ([]byte, error) {
+	customJSON := map[string]interface{}{
+		"typeName": "Purpose",
+		"attributes": map[string]interface{}{
+			"displayName":            p.Name,
+			"name":                   p.Name,
+			"qualifiedName":          p.Name,
+			"isAccessControlEnabled": true,
+		},
+	}
+
+	attributes := customJSON["attributes"].(map[string]interface{})
+
+	if p.QualifiedName != nil && *p.QualifiedName != "" {
+		attributes["qualifiedName"] = *p.QualifiedName
+	}
+
+	if p.IsAccessControlEnabled != nil {
+		attributes["isAccessControlEnabled"] = *p.IsAccessControlEnabled
+	}
+
+	if p.Description != nil && *p.Description != "" {
+		attributes["description"] = *p.Description
+	}
+
+	if p.DisplayName != nil && *p.DisplayName != "" {
+		attributes["displayName"] = *p.DisplayName
+	}
+
+	if p.Guid != nil && *p.Guid != "" {
+		customJSON["guid"] = *p.Guid
+	}
+
+	// Add access control attributes
+	if p.IsAccessControlEnabled != nil {
+		attributes["isAccessControlEnabled"] = *p.IsAccessControlEnabled
+	}
+	if p.DenyCustomMetadataGuids != nil {
+		attributes["denyCustomMetadataGuids"] = *p.DenyCustomMetadataGuids
+	}
+	if p.DenyAssetTabs != nil {
+		attributes["denyAssetTabs"] = *p.DenyAssetTabs
+	}
+	if p.DenyAssetFilters != nil {
+		attributes["denyAssetFilters"] = *p.DenyAssetFilters
+	}
+	if p.ChannelLink != nil {
+		attributes["channelLink"] = *p.ChannelLink
+	}
+	if p.DenyAssetTypes != nil {
+		attributes["denyAssetTypes"] = *p.DenyAssetTypes
+	}
+	if p.DenyNavigationPages != nil {
+		attributes["denyNavigationPages"] = *p.DenyNavigationPages
+	}
+	if p.DefaultNavigation != nil {
+		attributes["defaultNavigation"] = *p.DefaultNavigation
+	}
+	if p.DisplayPreferences != nil {
+		attributes["displayPreferences"] = *p.DisplayPreferences
+	}
+	if p.Policies != nil {
+		attributes["policies"] = p.Policies // Assuming proper JSON marshalling of structs.AuthPolicy
+	}
+
+	// Add other attributes here
+
+	return json.MarshalIndent(customJSON, "", "  ")
+}
+
+// ToJSON converts a Purpose object to JSON.
+func (p *Purpose) ToJSON() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// FromJSON populates a Purpose object from JSON.
+func (p *Purpose) FromJSON(data []byte) error {
+	return json.Unmarshal(data, p)
+}

--- a/atlan/assets/purpose_client.go
+++ b/atlan/assets/purpose_client.go
@@ -300,6 +300,9 @@ func (p *Purpose) MarshalJSON() ([]byte, error) {
 		customJSON["guid"] = *p.Guid
 	}
 
+	if p.Attributes != nil && p.Attributes.PurposeAtlanTags != nil && len(*p.Attributes.PurposeAtlanTags) > 0 {
+		attributes["purposeClassifications"] = p.Attributes.PurposeAtlanTags
+	}
 	// Add access control attributes
 	if p.IsAccessControlEnabled != nil {
 		attributes["isAccessControlEnabled"] = *p.IsAccessControlEnabled

--- a/atlan/assets/purpose_client_test.go
+++ b/atlan/assets/purpose_client_test.go
@@ -1,0 +1,153 @@
+package assets
+
+import (
+	"github.com/atlanhq/atlan-go/atlan"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+var PurposeName = atlan.MakeUnique("Purpose")
+
+func TestIntegrationPurpose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	NewContext()
+	//ctx.EnableLogging("debug")
+
+	purposeID, purposeQualifiedName := testCreatePurpose(t)
+	testRetrievePurpose(t, purposeID)
+	testPurposeCreateMetadataPolicy(t, purposeID)
+	testPurposeCreateDataPolicy(t, purposeID)
+	testFindPurposesByName(t)
+	testUpdatePurpose(t, purposeQualifiedName)
+	testDeletePurpose(t, purposeID)
+}
+
+func testCreatePurpose(t *testing.T) (string, string) {
+	p := &Purpose{}
+	// Create Purpose
+	atlanTags := []string{"Issue", "Confidential"}
+	err := p.Creator(PurposeName, atlanTags)
+	assert.NoError(t, err, "creator should not return an error")
+
+	response, err := Save(p)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, response, "fetched purpose should not be nil")
+	assert.Equal(t, 1, len(response.MutatedEntities.CREATE), "number of purposes created should be 1")
+	assert.Equal(t, 0, len(response.MutatedEntities.UPDATE), "number of purposes updated should be 0")
+	assert.Equal(t, 0, len(response.MutatedEntities.DELETE), "number of purposes deleted should be 0")
+	CreatedPurpose := response.MutatedEntities.CREATE[0]
+	assert.NotNil(t, CreatedPurpose, "purpose should not be nil")
+	assert.Equal(t, PurposeName, *CreatedPurpose.Attributes.Name, "purpose name should match")
+	assert.Equal(t, *p.TypeName, CreatedPurpose.TypeName, "purpose type should match")
+
+	return CreatedPurpose.Guid, *CreatedPurpose.Attributes.QualifiedName
+}
+
+func testRetrievePurpose(t *testing.T, purposeID string) {
+	purpose, err := GetByGuid[*Purpose](purposeID)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, purpose, "fetched purpose should not be nil")
+	assert.Equal(t, PurposeName, *purpose.Name, "purpose name should match")
+}
+
+func testFindPurposesByName(t *testing.T) {
+	time.Sleep(3 * time.Second)
+	purposes, err := FindPurposesByName(PurposeName)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, purposes.Entities, "fetched purposes should not be nil")
+	assert.Equal(t, int64(1), purposes.ApproximateCount, "number of purposes fetched should be 1")
+	assert.Equal(t, PurposeName, *purposes.Entities[0].Name, "purpose name should match")
+}
+
+func testPurposeCreateMetadataPolicy(t *testing.T, purposeID string) {
+	p := &Purpose{}
+	policy, err := p.CreateMetadataPolicy(
+		PurposeName,
+		purposeID,
+		atlan.AuthPolicyTypeAllow,
+		[]atlan.PurposeMetadataAction{
+			atlan.PurposeMetadataActionRead,
+		},
+		nil,
+		nil,
+		true,
+	)
+	response, err := Save(policy)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, response, "fetched policy should not be nil")
+	assert.Equal(t, 1, len(response.MutatedEntities.CREATE), "number of policies added should be 1")
+	CreatedPolicy := response.MutatedEntities.CREATE[0]
+	assert.NotNil(t, CreatedPolicy, "policy should not be nil")
+}
+
+func testPurposeCreateDataPolicy(t *testing.T, purposeID string) {
+	p := &Purpose{}
+	policy, err := p.CreateDataPolicy(
+		PurposeName,
+		purposeID,
+		atlan.AuthPolicyTypeAllow,
+		nil,
+		nil,
+		true,
+	)
+	response, err := Save(policy)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, response, "fetched policy should not be nil")
+	assert.Equal(t, 1, len(response.MutatedEntities.CREATE), "number of policies added should be 1")
+	CreatedPolicy := response.MutatedEntities.CREATE[0]
+	assert.NotNil(t, CreatedPolicy, "policy should not be nil")
+}
+
+func testUpdatePurpose(t *testing.T, purposeQualifiedName string) {
+	p := &Purpose{}
+	NewName := atlan.MakeUnique("test-update-purpose")
+	Description := atlan.MakeUnique("test-update-purpose-description")
+	err := p.Updater(purposeQualifiedName, PurposeName, true)
+	assert.NoError(t, err, "updater should not return an error")
+
+	p.Name = &NewName
+	p.Description = &Description
+	UpdaterResponse, err := Save(p)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	assert.NotNil(t, UpdaterResponse, "fetched purpose should not be nil")
+	assert.Equal(t, 1, len(UpdaterResponse.MutatedEntities.UPDATE), "number of purposes updated should be 1")
+	assert.Equal(t, *p.Name, *UpdaterResponse.MutatedEntities.UPDATE[0].Attributes.Name, "purpose name should match")
+	assert.Equal(t, *p.Description, *UpdaterResponse.MutatedEntities.UPDATE[0].Attributes.Description, "purpose description should match")
+}
+
+func testDeletePurpose(t *testing.T, purposeID string) {
+	DeleteResponse, err := PurgeByGuid([]string{purposeID})
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	//for _, deleted := range DeleteResponse.MutatedEntities.DELETE {
+	//	t.Logf("Deleted: %v", deleted)
+	//}
+	assert.NotNil(t, DeleteResponse, "fetched purpose should not be nil")
+	assert.Equal(t, 3, len(DeleteResponse.MutatedEntities.DELETE), "number of purposes deleted should be 3") // 3 because of the metadata and data policies
+
+	// Collect GUIDs from the server response
+	serverGuids := make([]string, len(DeleteResponse.MutatedEntities.DELETE))
+	for i, deleted := range DeleteResponse.MutatedEntities.DELETE {
+		serverGuids[i] = deleted.Guid
+	}
+
+	// Ensure the expected purposeID is in the list of server-provided GUIDs
+	assert.Contains(t, serverGuids, purposeID, "purpose guid should match one of the server-provided GUIDs")
+}

--- a/atlan/model/search.go
+++ b/atlan/model/search.go
@@ -845,6 +845,7 @@ func (sa *SearchAssets) UnmarshalJSON(data []byte) error {
 		structs.AuthPolicy
 		structs.AccessControl
 		structs.Persona
+		structs.Purpose
 		QualifiedName       *string           `json:"qualifiedName,omitempty"`
 		Name                *string           `json:"name,omitempty"`
 		SearchAttributes    *SearchAttributes `json:"attributes,omitempty"`

--- a/atlan/model/structs/access_control.go
+++ b/atlan/model/structs/access_control.go
@@ -1,6 +1,8 @@
 package structs
 
-import "github.com/atlanhq/atlan-go/atlan"
+import (
+	"github.com/atlanhq/atlan-go/atlan"
+)
 
 // AccessControl represents the attributes of the AccessControl asset.
 type AccessControl struct {
@@ -49,4 +51,20 @@ type Persona struct {
 	PersonaGroups *[]string `json:"personaGroups,omitempty"`
 	PersonaUsers  *[]string `json:"personaUsers,omitempty"`
 	RoleId        *string   `json:"roleId,omitempty"`
+}
+
+type Purpose struct {
+	AccessControl
+	Attributes *PurposeAttributes `json:"attributes,omitempty"`
+}
+
+// PurposeAttributes represents the additional attributes for a Purpose asset.
+type PurposeAttributes struct {
+	PurposeAtlanTags *[]AtlanTagName `json:"purposeAtlanTags,omitempty"`
+}
+
+// AtlanTagName represents the attributes of the AtlanTagName asset.
+type AtlanTagName struct {
+	ID          string `json:"id,omitempty"`
+	DisplayText string `json:"displayText,omitempty"`
 }

--- a/atlan/model/typedef.go
+++ b/atlan/model/typedef.go
@@ -25,6 +25,7 @@ type StructDef struct {
 
 type EntityDef struct {
 	TypeDef
+	TypeDefBase
 }
 
 type RelationshipDef struct {

--- a/main.go
+++ b/main.go
@@ -12,13 +12,191 @@ func main() {
 	ctx := assets.NewContext()
 	ctx.EnableLogging("debug")
 
-	// Test User Cache
-	UserId, err := assets.GetGroupNameForGroupID("58d547d8-3f4d-4b9e-9666-39980f140661")
+	// Update a Purpose
+	purpose := &assets.Purpose{}
+	err := purpose.Updater("default/yvdelhXJLpf3LGxtg46DQb", "gsdk_Purpose_7mLrt", true)
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Println(err)
+		return
 	}
-	fmt.Println(UserId)
-	
+	DisplayName := "Newly Modified Test Purpose"
+	Description := "This is a modified description"
+	purpose.Name = &DisplayName
+	purpose.Description = &Description
+	response, err := assets.Save(purpose)
+	if err != nil {
+		println("Error:", err)
+	} else {
+		for _, entity := range response.MutatedEntities.UPDATE {
+			println("Response:", entity)
+			println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+		}
+
+	}
+
+	/*
+		// Delete a Purpose
+		assets.PurgeByGuid([]string{"a947beac-ae4d-4d1c-a9f8-efd9c55fe768"})
+	*/
+	/*
+		// List purposes
+		response, atlanErr := assets.NewFluentSearch(). //
+								PageSizes(20).
+								ActiveAssets().
+								AssetType("Purpose"). //
+								Execute()             //
+		if atlanErr != nil {
+			fmt.Println("Error:", atlanErr)
+		}
+		for _, entity := range response[0].Entities { //
+			if entity.TypeName != nil && *entity.TypeName == "Purpose" {
+				// Do something with the Purpose
+				fmt.Println("Purpose Found:", *entity.Name, "QualifiedName:", *entity.QualifiedName)
+				fmt.Println("Purpose guid:", *entity.Guid)
+			}
+		}
+
+
+	*/
+
+	/*
+		// Personalize the purpose
+		purpose := &assets.Purpose{}
+		purpose.Updater("default/0IFqLjT5JqnZrWOp2U1IUB", "Newly Modified Test Purpose", true)
+		purpose.DenyAssetTabs = &[]string{atlan.AssetSidebarTabLineage.Name, atlan.AssetSidebarTabRelations.Name, atlan.AssetSidebarTabQueries.Name}
+		response, _ := assets.Save(purpose)
+		for _, entity := range response.MutatedEntities.UPDATE {
+			println("Response:", entity)
+			println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+
+		}
+	*/
+	/*
+		// Add a Data Policy
+		purpose := &assets.Purpose{}
+		policy, _ := purpose.CreateDataPolicy(
+			"Test Policy for Masking Data",
+			"a947beac-ae4d-4d1c-a9f8-efd9c55fe768",
+			atlan.AuthPolicyTypeDatamask,
+			nil,
+			nil,
+			true,
+		)
+		response, err := assets.Save(policy)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response TypeName:", entity.TypeName)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+
+		}
+
+
+	*/
+	/*
+		// Add a metadata Policy
+		purpose := &assets.Purpose{}
+		policy, _ := purpose.CreateMetadataPolicy(
+			"Test Policy 3",
+			"a947beac-ae4d-4d1c-a9f8-efd9c55fe768",
+			atlan.AuthPolicyTypeAllow,
+			[]atlan.PurposeMetadataAction{
+				atlan.PurposeMetadataActionRead,
+			},
+			nil,
+			nil,
+			true,
+		)
+		response, err := assets.Save(policy)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response TypeName:", entity.TypeName)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+
+		}
+
+
+	*/
+	/*
+		// Activate or Deactivate a Purpose
+		purpose := &assets.Purpose{}
+		err := purpose.Updater("default/0IFqLjT5JqnZrWOp2U1IUB", "Newly Modified Test Purpose", false)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		response, err := assets.Save(purpose)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.UPDATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+
+		}
+
+
+	*/
+	/*
+		// Update a Purpose
+		purpose := &assets.Purpose{}
+		err := purpose.Updater("default/0IFqLjT5JqnZrWOp2U1IUB", "Test Purpose Modified", true)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		DisplayName := "Newly Modified Test Purpose"
+		Description := "This is a modified description"
+		purpose.Name = &DisplayName
+		purpose.Description = &Description
+		response, err := assets.Save(purpose)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.UPDATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+
+		}
+
+	*/
+	/*
+		// Retrieve Persona by Name
+		result, _ := assets.FindPurposesByName("Test Purpose - Go-sdk")
+		fmt.Println(*result.Entities[0].Name)
+
+	*/
+	/*
+		// Create a Purpose
+		purpose := &assets.Purpose{}
+		purpose.Creator("Test Purpose - Go-sdk", []string{"Confidential", "Issue"})
+		response, err := assets.Save(purpose)
+		if err != nil {
+			println("Error:", err)
+		} else {
+			for _, entity := range response.MutatedEntities.CREATE {
+				println("Response:", entity)
+				println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+			}
+		}
+		// a947beac-ae4d-4d1c-a9f8-efd9c55fe768
+	*/
+
+	/*
+		// Test User Cache
+		UserId, err := assets.GetGroupNameForGroupID("58d547d8-3f4d-4b9e-9666-39980f140661")
+		if err != nil {
+			fmt.Println("Error:", err)
+		}
+		fmt.Println(UserId)
+	*/
 	/*
 		// Delete an API Token
 		err := ctx.TokenClient.Purge("a853f1d5-f1f4-4cdb-b86d-c61df3ecade6")


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
This PR adds support for managing purposes in the Go SDK. It includes methods for creating, updating, retrieving, and deleting purposes, as well as methods for creating data and metadata policies linked to a purpose.
## Related Issue
<!-- Link any relevant issue or ticket -->
FT-807
## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
