### PR TITLE
APP-5003 : Fixes maximum token TTE to 5 years

### DIFF
--- a/atlan/assets/token_client_test.go
+++ b/atlan/assets/token_client_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	TestDisplayName    = atlan.MakeUnique("test-api-token")
 	TestDescription    = atlan.MakeUnique("Test API Token Description")
-	MaxValiditySeconds = 409968000
+	MaxValiditySeconds = 157680000
 )
 
 func TestIntegrationTokenClient(t *testing.T) {

--- a/atlan/model/structs/api_tokens.go
+++ b/atlan/model/structs/api_tokens.go
@@ -6,8 +6,10 @@ import (
 	"math"
 )
 
-const ServiceAccount = "SERVICE_ACCOUNT_"
-const MaxValidity = 157680000
+const (
+	ServiceAccount = "SERVICE_ACCOUNT_"
+	MaxValidity    = 157680000
+)
 
 // ApiTokenPersona represents a linked persona in the API token model.
 type ApiTokenPersona struct {

--- a/atlan/model/structs/api_tokens.go
+++ b/atlan/model/structs/api_tokens.go
@@ -8,7 +8,10 @@ import (
 
 const (
 	ServiceAccount = "SERVICE_ACCOUNT_"
-	MaxValidity    = 157680000
+	// The value was previously set to 13 years (409968000 secs).
+	// It has been reverted to 5 years due to an integer overflow issue in Keycloak.
+	// https://github.com/keycloak/keycloak/issues/19671
+	MaxValidity = 157680000 // 5 years in seconds
 )
 
 // ApiTokenPersona represents a linked persona in the API token model.

--- a/atlan/model/structs/api_tokens.go
+++ b/atlan/model/structs/api_tokens.go
@@ -3,9 +3,11 @@ package structs
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 )
 
 const ServiceAccount = "SERVICE_ACCOUNT_"
+const MaxValidity = 157680000
 
 // ApiTokenPersona represents a linked persona in the API token model.
 type ApiTokenPersona struct {
@@ -135,9 +137,10 @@ type ApiTokenRequest struct {
 func (r *ApiTokenRequest) SetMaxValidity() {
 	if r.ValiditySeconds != nil {
 		if *r.ValiditySeconds < 0 {
-			*r.ValiditySeconds = 409968000
-		} else if *r.ValiditySeconds > 409968000 {
-			*r.ValiditySeconds = 409968000
+			*r.ValiditySeconds = MaxValidity // Treat negative numbers as "infinite" (never expire)
+		} else if *r.ValiditySeconds > MaxValidity {
+			// Otherwise use "infinite" as the ceiling for values
+			*r.ValiditySeconds = int(math.Min(float64(*r.ValiditySeconds), MaxValidity))
 		}
 	}
 	if r.Personas == nil {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
Set maximum token validity to 5 years in order to avoid issue with keycloack [2038](https://en.wikipedia.org/wiki/Year_2038_problem) bug which leads to integer overflow by setting negative value.

## Related Issue
<!-- Link any relevant issue or ticket -->
APP-5003

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
