### PR TITLE
APP-5079 : Manage Policies

### DIFF
--- a/atlan/assets/asset.go
+++ b/atlan/assets/asset.go
@@ -71,6 +71,7 @@ type AssetFields struct {
 	VIEWER_GROUPS              *KeywordField
 	CONNECTOR_NAME             *KeywordTextField
 	CONNECTION_NAME            *KeywordTextField
+	CONNECTION_QUALIFIED_NAME  *KeywordTextField
 }
 
 type CatalogFields struct {
@@ -366,6 +367,7 @@ func NewSearchTable() *AtlasTableFields {
 					VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 					VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 					CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+					CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 				},
 				INPUT_TO_PROCESSES:        NewRelationField("inputToProcesses"),
 				OUTPUT_FROM_AIRFLOW_TASKS: NewRelationField("outputFromAirflowTasks"),
@@ -432,6 +434,7 @@ func NewSearchColumn() *ColumnFields {
 					VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 					VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 					CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+					CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 				},
 				INPUT_TO_PROCESSES:        NewRelationField("inputToProcesses"),
 				OUTPUT_FROM_AIRFLOW_TASKS: NewRelationField("outputFromAirflowTasks"),
@@ -561,6 +564,7 @@ func NewSearchConnection() *ConnectionFields {
 			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+			CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 		},
 		CATEGORY:                        NewKeywordField("category", "category"),
 		SUB_CATEGORY:                    NewKeywordField("subCategory", "subCategory"),
@@ -628,6 +632,7 @@ func NewSearchGlossary() *AtlasGlossaryFields {
 			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+			CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 		},
 	}
 }
@@ -669,6 +674,7 @@ func NewSearchMaterialisedView() *MaterialisedViewFields {
 					VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 					VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 					CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+					CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 				},
 				INPUT_TO_PROCESSES:        NewRelationField("inputToProcesses"),
 				OUTPUT_FROM_AIRFLOW_TASKS: NewRelationField("outputFromAirflowTasks"),
@@ -749,6 +755,7 @@ func NewSearchView() *ViewFields {
 					VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 					VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 					CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+					CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 				},
 				INPUT_TO_PROCESSES:        NewRelationField("inputToProcesses"),
 				OUTPUT_FROM_AIRFLOW_TASKS: NewRelationField("outputFromAirflowTasks"),
@@ -835,6 +842,7 @@ func NewAccessControlFields() *AccessControlFields {
 			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+			CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 		},
 	}
 }
@@ -886,6 +894,7 @@ func NewPersonaFields() *PersonaFields {
 				VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 				VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 				CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+				CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 			},
 		},
 		PERSONA_GROUPS: NewKeywordField("personaGroups", "personaGroups"),
@@ -930,6 +939,7 @@ func NewAuthPolicyFields() *AuthPolicyFields {
 			VIEWER_USERS:               NewKeywordField("viewerUsers", "viewerUsers"),
 			VIEWER_GROUPS:              NewKeywordField("viewerGroups", "viewerGroups"),
 			CONNECTOR_NAME:             NewKeywordTextField("connectorName", "connectorName", "connectorName.text"),
+			CONNECTION_QUALIFIED_NAME:  NewKeywordTextField("connectionQualifiedName", "connectionQualifiedName", "connectionQualifiedName.text"),
 		},
 		POLICY_TYPE:               NewKeywordField("policyType", "policyType"),
 		POLICY_SERVICE_NAME:       NewKeywordField("policyServiceName", "policyServiceName"),

--- a/atlan/assets/atlan_fields.go
+++ b/atlan/assets/atlan_fields.go
@@ -107,6 +107,16 @@ func NewKeywordField(atlanFieldName, keywordFieldName string) *KeywordField {
 	}
 }
 
+// StartsWith Returns a query that will match all assets whose field has a value that starts with
+// the provided value. Note that this can also be a case-insensitive match.
+func (kf *KeywordField) StartsWith(value string, caseInsensitive *bool) model.Query {
+	return &model.PrefixQuery{
+		Field:           kf.KeywordFieldName,
+		Value:           value,
+		CaseInsensitive: caseInsensitive,
+	}
+}
+
 func (kf *KeywordField) GetKeywordFieldName() string {
 	return kf.KeywordFieldName
 }

--- a/atlan/assets/purpose_client.go
+++ b/atlan/assets/purpose_client.go
@@ -241,6 +241,18 @@ func (p *Purpose) UnmarshalJSON(data []byte) error {
 
 		// Purpose-specific attributes
 		PurposeAtlanTags *[]structs.AtlanTagName `json:"purposeAtlanTags,omitempty"`
+
+		// Access Control-specific Attributes
+		IsAccessControlEnabled  *bool         `json:"isAccessControlEnabled,omitempty"`
+		DenyCustomMetadataGuids *[]string     `json:"denyCustomMetadataGuids,omitempty"`
+		DenyAssetTabs           *[]string     `json:"denyAssetTabs,omitempty"`
+		DenyAssetFilters        *[]string     `json:"denyAssetFilters,omitempty"`
+		ChannelLink             *string       `json:"channelLink,omitempty"`
+		DenyAssetTypes          *[]string     `json:"denyAssetTypes,omitempty"`
+		DenyNavigationPages     *[]string     `json:"denyNavigationPages,omitempty"`
+		DefaultNavigation       *string       `json:"defaultNavigation,omitempty"`
+		DisplayPreferences      *[]string     `json:"displayPreferences,omitempty"`
+		Policies                *[]AuthPolicy `json:"policies,omitempty"`
 	}{}
 	base, err := UnmarshalBaseEntity(data, &attributes)
 	if err != nil {
@@ -262,6 +274,30 @@ func (p *Purpose) UnmarshalJSON(data []byte) error {
 	p.Name = attributes.Name
 	p.Attributes = &structs.PurposeAttributes{
 		PurposeAtlanTags: attributes.PurposeAtlanTags,
+	}
+
+	// Map Access Control Attributes
+	p.IsAccessControlEnabled = attributes.IsAccessControlEnabled
+	p.DenyCustomMetadataGuids = attributes.DenyCustomMetadataGuids
+	p.DenyAssetTabs = attributes.DenyAssetTabs
+	p.DenyAssetFilters = attributes.DenyAssetFilters
+	p.ChannelLink = attributes.ChannelLink
+	p.DenyAssetTypes = attributes.DenyAssetTypes
+	p.DenyNavigationPages = attributes.DenyNavigationPages
+	p.DefaultNavigation = attributes.DefaultNavigation
+	p.DisplayPreferences = attributes.DisplayPreferences
+
+	// Unmarshal RelationshipAttributes for Policies
+	if base.Entity.RelationshipAttributes != nil {
+		relationshipAttributes := struct {
+			Policies []structs.AuthPolicy `json:"policies,omitempty"`
+		}{}
+
+		if err := json.Unmarshal(base.Entity.RelationshipAttributes, &relationshipAttributes); err != nil {
+			return err
+		}
+		// Map the Policies field
+		p.Policies = &relationshipAttributes.Policies
 	}
 
 	return nil

--- a/atlan/model/structs/access_control.go
+++ b/atlan/model/structs/access_control.go
@@ -17,6 +17,9 @@ type AccessControl struct {
 	DefaultNavigation       *string       `json:"defaultNavigation,omitempty"`
 	DisplayPreferences      *[]string     `json:"displayPreferences,omitempty"`
 	Policies                *[]AuthPolicy `json:"policies,omitempty"` // Relationship
+	UniqueAttributes        struct {
+		QualifiedName *string `json:"qualifiedName,omitempty"`
+	} `json:"uniqueAttributes,omitempty"`
 }
 
 // AuthPolicy represents a policy with various attributes.

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	_ "github.com/atlanhq/atlan-go/atlan"
 	"github.com/atlanhq/atlan-go/atlan/assets"
 	_ "github.com/atlanhq/atlan-go/atlan/model/structs"
@@ -12,27 +10,120 @@ func main() {
 	ctx := assets.NewContext()
 	ctx.EnableLogging("debug")
 
-	// Update a Purpose
-	purpose := &assets.Purpose{}
-	err := purpose.Updater("default/yvdelhXJLpf3LGxtg46DQb", "gsdk_Purpose_7mLrt", true)
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	DisplayName := "Newly Modified Test Purpose"
-	Description := "This is a modified description"
-	purpose.Name = &DisplayName
-	purpose.Description = &Description
-	response, err := assets.Save(purpose)
-	if err != nil {
-		println("Error:", err)
-	} else {
-		for _, entity := range response.MutatedEntities.UPDATE {
-			println("Response:", entity)
-			println("Entity ID:", entity.Guid, "Display Text:", entity.DisplayText)
+	/*
+		// Find the GUID of a specific policy in a persona
+		PurposeName := "Test-go-sdk-Purpose"
+		result, atlanErr := assets.FindPurposesByName(PurposeName)
+		if atlanErr != nil {
+			log.Fatal(atlanErr)
 		}
-	}
+		fmt.Println(*result.Entities[0].Guid)
+		purpose, _ := assets.GetByGuid[*assets.Purpose](*result.Entities[0].Guid)
+		for _, policy := range *purpose.Policies {
+			println("Policy Found: Guid:", *policy.Guid)
+			println("Policy Found: Name:", *policy.DisplayName)
+		}
+	*/
+	/*
+		// Find the GUID of a specific policy in a persona
+		PersonaName := "Test Persona - Go-sdk"
+		result, atlanErr := assets.FindPersonasByName(PersonaName)
+		if atlanErr != nil {
+			log.Fatal(atlanErr)
+		}
+		fmt.Println(*result.Entities[0].Guid)
+		persona, _ := assets.GetByGuid[*assets.Persona](*result.Entities[0].Guid)
+		for _, policy := range *persona.Policies {
+			println("Policy Found: Guid:", *policy.Guid)
+			println("Policy Found: Name:", *policy.DisplayName)
+		}
 
+	*/
+	/*
+		// Update Policy through Persona/Purpose
+		response, atlanErr := assets.NewFluentSearch().
+			AssetType("AuthPolicy").
+			Where(ctx.AuthPolicy.POLICY_CATEGORY.Eq("persona")).
+			Where(ctx.AuthPolicy.GUID.Eq("da6bc10c-c2f0-4945-9592-9b4cc75cbc7b")).
+			//Where(ctx.AuthPolicy.POLICY_RESOURCES.StartsWith("entity:default/snowflake/1738006574", nil)).
+			IncludeOnResults(ctx.AuthPolicy.NAME.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.ACCESS_CONTROL.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_RESOURCES.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.CONNECTION_QUALIFIED_NAME.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_TYPE.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_SUB_CATEGORY.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.IS_ACCESS_CONTROL_ENABLED.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.NAME.GetAtlanFieldName()).
+			Execute()
+		if atlanErr != nil {
+			log.Fatal(atlanErr)
+		}
+		for _, entity := range response[0].Entities {
+			if entity.TypeName != nil && *entity.TypeName == "AuthPolicy" {
+				fmt.Println("AuthPolicy Found: Name:", *entity.Name, "QualifiedName:", *entity.QualifiedName)
+				fmt.Println("AuthPolicy guid:", *entity.Guid)
+				fmt.Println("Policy Resources:", *entity.PolicyResources)
+				fmt.Println(*entity.AccessControl.TypeName)
+				entity.PolicyType = &atlan.AuthPolicyTypeDeny
+				_, err := assets.Save(&entity)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+
+	*/
+	/*
+		// Retrieving policies from a purpose
+		response, atlanErr := assets.NewFluentSearch().
+			AssetType("AuthPolicy").
+			Where(ctx.AuthPolicy.POLICY_CATEGORY.Eq("purpose")).
+			//Where(ctx.AuthPolicy.POLICY_RESOURCES.StartsWith("tag:TLwvfawpBhZb6JIQgVc0Fn", nil)).
+			IncludeOnResults(ctx.AuthPolicy.NAME.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.ACCESS_CONTROL.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_RESOURCES.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.IS_ACCESS_CONTROL_ENABLED.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.NAME.GetAtlanFieldName()).
+			Execute()
+		if atlanErr != nil {
+			log.Fatal(atlanErr)
+		}
+		for _, entity := range response[0].Entities {
+			if entity.TypeName != nil && *entity.TypeName == "AuthPolicy" {
+				println("AuthPolicy Found: Name:", *entity.Name, "QualifiedName:", *entity.QualifiedName)
+				println("AuthPolicy guid:", *entity.Guid)
+				println("Policy Resources:", *entity.PolicyResources)
+			}
+		}
+
+	*/
+	/*
+		// Retrieving policies from a persona
+		response, atlanErr := assets.NewFluentSearch().
+			AssetType("AuthPolicy").
+			Where(ctx.AuthPolicy.POLICY_CATEGORY.Eq("persona")).
+			Where(ctx.AuthPolicy.POLICY_RESOURCES.StartsWith("entity:default/snowflake/1738006457", nil)).
+			IncludeOnResults(ctx.AuthPolicy.NAME.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.ACCESS_CONTROL.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_RESOURCES.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.CONNECTION_QUALIFIED_NAME.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_TYPE.GetAtlanFieldName()).
+			IncludeOnResults(ctx.AuthPolicy.POLICY_SUB_CATEGORY.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.IS_ACCESS_CONTROL_ENABLED.GetAtlanFieldName()).
+			IncludeOnRelations(ctx.AccessControl.NAME.GetAtlanFieldName()).
+			Execute()
+		if atlanErr != nil {
+			log.Fatal(atlanErr)
+		}
+		for _, entity := range response[0].Entities {
+			if entity.TypeName != nil && *entity.TypeName == "AuthPolicy" {
+				fmt.Println("AuthPolicy Found: Name:", *entity.Name, "QualifiedName:", *entity.QualifiedName)
+				fmt.Println("AuthPolicy guid:", *entity.Guid)
+				fmt.Println("Policy Resources:", *entity.PolicyResources)
+			}
+		}
+
+	*/
 	/*
 		// Delete a Purpose
 		assets.PurgeByGuid([]string{"a947beac-ae4d-4d1c-a9f8-efd9c55fe768"})


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
This PR updates the AuthPolicy struct to improve JSON Unmarshalling and Marshalling and enhance policy search using Persona and Purpose.
	•	Adds handling for nested accessControl fields returned in index search responses.
	•	Manually tested search methods for managing policies through Purpose and Persona in main.go.

>  Since [Managing Policies](https://developer.atlan.com/snippets/access/policies/) already uses IndexSearch with Persona and Purpose, there’s no need to create new integration tests for existing methods.

## Related Issue
<!-- Link any relevant issue or ticket -->
APP-5079
## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
