### PR TITLE
APP-5147 : Add DataMaskingType enums

### DIFF
--- a/atlan/assets/auth_policy_client.go
+++ b/atlan/assets/auth_policy_client.go
@@ -41,7 +41,7 @@ func (a *AuthPolicy) UnmarshalJSON(data []byte) error {
 		PolicyResourceCategory  *string                             `json:"policyResourceCategory,omitempty"`
 		PolicyPriority          *int                                `json:"policyPriority,omitempty"`
 		IsPolicyEnabled         *bool                               `json:"isPolicyEnabled,omitempty"`
-		PolicyMaskType          *string                             `json:"policyMaskType,omitempty"`
+		PolicyMaskType          *atlan.DataMaskingType              `json:"policyMaskType,omitempty"`
 		PolicyValiditySchedule  *[]atlan.AuthPolicyValiditySchedule `json:"policyValiditySchedule,omitempty"`
 		PolicyResourceSignature *string                             `json:"policyResourceSignature,omitempty"`
 		PolicyDelegateAdmin     *bool                               `json:"policyDelegateAdmin,omitempty"`
@@ -154,6 +154,10 @@ func (a *AuthPolicy) MarshalJSON() ([]byte, error) {
 
 	if a.PolicyUsers != nil && len(*a.PolicyUsers) > 0 {
 		attributes["policyUsers"] = *a.PolicyUsers
+	}
+
+	if a.PolicyMaskType != nil {
+		attributes["policyMaskType"] = *a.PolicyMaskType
 	}
 
 	// Handle nested AccessControl field

--- a/atlan/enums.go
+++ b/atlan/enums.go
@@ -3200,3 +3200,51 @@ func (c *AssetFilterGroup) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+type DataMaskingType struct {
+	Name string
+}
+
+func (d DataMaskingType) String() string {
+	return d.Name
+}
+
+var (
+	DataMaskingTypeSHOWFIRST4 = DataMaskingType{"MASK_SHOW_FIRST_4"}
+	DataMaskingTypeSHOWLAST4  = DataMaskingType{"MASK_SHOW_LAST_4"}
+	DataMaskingTypeHASH       = DataMaskingType{"MASK_HASH"}
+	DataMaskingTypeNULLIFY    = DataMaskingType{"MASK_NULL"}
+	DataMaskingTypeREDACT     = DataMaskingType{"MASK_REDACT"}
+)
+
+// UnmarshalJSON customizes the unmarshalling of a DataMaskingType from JSON.
+func (d *DataMaskingType) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+
+	switch name {
+	case "MASK_SHOW_FIRST_4":
+		*d = DataMaskingTypeSHOWFIRST4
+
+	case "MASK_SHOW_LAST_4":
+		*d = DataMaskingTypeSHOWLAST4
+
+	case "MASK_HASH":
+		*d = DataMaskingTypeHASH
+	case "MASK_NULL":
+		*d = DataMaskingTypeNULLIFY
+	case "MASK_REDACT":
+		*d = DataMaskingTypeREDACT
+	default:
+		*d = DataMaskingType{Name: name}
+	}
+
+	return nil
+}
+
+// MarshalJSON customizes the marshalling of a DataMaskingType to JSON.
+func (d DataMaskingType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Name)
+}

--- a/atlan/model/search.go
+++ b/atlan/model/search.go
@@ -645,7 +645,7 @@ type SearchAttributes struct {
 	PolicyResourceCategory  *string                             `json:"policyResourceCategory,omitempty"`
 	PolicyPriority          *int                                `json:"policyPriority,omitempty"`
 	IsPolicyEnabled         *bool                               `json:"isPolicyEnabled,omitempty"`
-	PolicyMaskType          *string                             `json:"policyMaskType,omitempty"`
+	PolicyMaskType          *atlan.DataMaskingType              `json:"policyMaskType,omitempty"`
 	PolicyValiditySchedule  *[]atlan.AuthPolicyValiditySchedule `json:"policyValiditySchedule,omitempty"`
 	PolicyResourceSignature *string                             `json:"policyResourceSignature,omitempty"`
 	PolicyDelegateAdmin     *bool                               `json:"policyDelegateAdmin,omitempty"`

--- a/atlan/model/structs/access_control.go
+++ b/atlan/model/structs/access_control.go
@@ -40,7 +40,7 @@ type AuthPolicy struct {
 	PolicyResourceCategory  *string                             `json:"policyResourceCategory,omitempty"`
 	PolicyPriority          *int                                `json:"policyPriority,omitempty"`
 	IsPolicyEnabled         *bool                               `json:"isPolicyEnabled,omitempty"`
-	PolicyMaskType          *string                             `json:"policyMaskType,omitempty"`
+	PolicyMaskType          *atlan.DataMaskingType              `json:"policyMaskType,omitempty"`
 	PolicyValiditySchedule  *[]atlan.AuthPolicyValiditySchedule `json:"policyValiditySchedule,omitempty"`
 	PolicyResourceSignature *string                             `json:"policyResourceSignature,omitempty"`
 	PolicyDelegateAdmin     *bool                               `json:"policyDelegateAdmin,omitempty"`


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
DataMaskingType enums are used in setting Masking Type while creating a Data Policy.

## Related Issue
<!-- Link any relevant issue or ticket -->

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
