### PR TITLE
APP-5187 : Add a check for creating or using an existing user

### DIFF
--- a/atlan/assets/group_client_test.go
+++ b/atlan/assets/group_client_test.go
@@ -97,7 +97,12 @@ func testRetrieveGroupByName(t *testing.T) {
 func testAddUsersToGroup(t *testing.T, groupID string) {
 	client := &GroupClient{}
 
-	user, err := client.UserClient.GetByEmail(UserEmail, 1, 0)
+	// This is a dependency issue on user-client test (which creates the user). This test runs before the user-client test
+	// which creates an issue if the user doesn't exist. So, we add a check here.
+	// Checks if the test user exists or not and creates it if it doesn't
+	testUser := getOrCreateTestUser(t)
+	// Directly uses the Email from the created / existing user
+	user, err := client.UserClient.GetByEmail(testUser.Email, 1, 0)
 	require.NoError(t, err, "error should be nil while getting user by email")
 	err = client.UserClient.AddUserToGroups(user[0].ID, []string{groupID})
 	require.NoError(t, err, "error should be nil while adding user to group")


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
The group-client tests, which rely on an existing user, runs before the user-client tests that create users, causing a dependency issue. This PR fixes the problem by checking if the test user already exists and creating it if needed.

## Related Issue
<!-- Link any relevant issue or ticket -->
APP-5187

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
