### PR TITLE
APP-5666 : Implement lazy loading / Fetching in `FluentSearch`

### DIFF
--- a/atlan/assets/fluent_search.go
+++ b/atlan/assets/fluent_search.go
@@ -137,7 +137,7 @@ func (fs *FluentSearch) IncludeOnRelations(fields ...string) *FluentSearch {
 }
 
 // Execute performs the search and returns the results.
-func (fs *FluentSearch) Execute() ([]*model.IndexSearchResponse, error) {
+func (fs *FluentSearch) Execute() *IndexSearchIterator {
 	if fs.PageSize == 0 {
 		fs.PageSize = 300 // Set Default Page Size
 	}
@@ -145,21 +145,7 @@ func (fs *FluentSearch) Execute() ([]*model.IndexSearchResponse, error) {
 	pageSize := fs.PageSize
 	request := fs.ToRequest()
 
-	iterator := NewIndexSearchIterator(pageSize, *request)
-	responses := make([]*model.IndexSearchResponse, 0)
-
-	for iterator.HasMoreResults() {
-		{
-			response, err := iterator.NextPage()
-			if err != nil {
-				// fmt.Printf("Error executing search: %v\n", err)
-				return nil, err
-			}
-
-			responses = append(responses, response)
-		}
-	}
-	return responses, nil
+	return NewIndexSearchIterator(pageSize, *request)
 }
 
 // Sort by GUID by default only if not already specified by the developer

--- a/atlan/assets/fluent_search_test.go
+++ b/atlan/assets/fluent_search_test.go
@@ -55,7 +55,7 @@ func TestIntegrationFluentSearch(t *testing.T) {
 	glossary := firstPage.Entities[0]
 
 	assert.NotNil(t, searchResult, "search result should not be nil")
-	assert.Len(t, searchResult, 1, "number of glossaries should be 1")
+	assert.Len(t, firstPage.Entities, 1, "number of glossaries should be 1")
 	assert.Equal(t, GlossaryName, *glossary.DisplayName, "glossary name should match")
 	assert.Equal(t, GlossaryDescription, *glossary.Description, "glossary description should exist")
 	assert.Equal(t, AnnouncementType, *glossary.AnnouncementType, "announcement type should exist")
@@ -77,7 +77,7 @@ func TestIntegrationFluentSearch(t *testing.T) {
 	firstPage, _ = searchResult.CurrentPage()
 	glossary = firstPage.Entities[0]
 
-	assert.Len(t, searchResult, 1, "number of glossaries should be 1")
+	assert.Len(t, firstPage.Entities, 1, "number of glossaries should be 1")
 	assert.Equal(t, "g", string((*glossary.DisplayName)[0]), "glossary name should start with G")
 
 	// Delete already created glossary

--- a/atlan/assets/fluent_search_test.go
+++ b/atlan/assets/fluent_search_test.go
@@ -41,7 +41,7 @@ func TestIntegrationFluentSearch(t *testing.T) {
 
 	time.Sleep(5 * time.Second)
 	// Search for glossary with Active Status and Name as GlossaryName
-	searchResult, err := NewFluentSearch().
+	searchResult := NewFluentSearch().
 		PageSizes(10).
 		ActiveAssets().
 		Where(ctx.Glossary.NAME.Eq(GlossaryName)).
@@ -51,17 +51,19 @@ func TestIntegrationFluentSearch(t *testing.T) {
 		fmt.Printf("Error executing search: %v\n", err)
 		return
 	}
+	firstPage, _ := searchResult.CurrentPage()
+	glossary := firstPage.Entities[0]
 
 	assert.NotNil(t, searchResult, "search result should not be nil")
 	assert.Len(t, searchResult, 1, "number of glossaries should be 1")
-	assert.Equal(t, GlossaryName, *searchResult[0].Entities[0].DisplayName, "glossary name should match")
-	assert.Equal(t, GlossaryDescription, *searchResult[0].Entities[0].Description, "glossary description should exist")
-	assert.Equal(t, AnnouncementType, *searchResult[0].Entities[0].AnnouncementType, "announcement type should exist")
-	assert.Equal(t, AnnouncementTitle, *searchResult[0].Entities[0].AnnouncementTitle, "announcement title should exist")
-	assert.Equal(t, AnnouncementMessage, *searchResult[0].Entities[0].AnnouncementMessage, "announcement message should exist")
+	assert.Equal(t, GlossaryName, *glossary.DisplayName, "glossary name should match")
+	assert.Equal(t, GlossaryDescription, *glossary.Description, "glossary description should exist")
+	assert.Equal(t, AnnouncementType, *glossary.AnnouncementType, "announcement type should exist")
+	assert.Equal(t, AnnouncementTitle, *glossary.AnnouncementTitle, "announcement title should exist")
+	assert.Equal(t, AnnouncementMessage, *glossary.AnnouncementMessage, "announcement message should exist")
 
 	// Search for glossaries starts with letter G and sort them in ascending order by name
-	searchResult, err = NewFluentSearch().
+	searchResult = NewFluentSearch().
 		PageSizes(10).
 		ActiveAssets().
 		Where(ctx.Glossary.NAME.StartsWith("gsdk", nil)).
@@ -72,8 +74,11 @@ func TestIntegrationFluentSearch(t *testing.T) {
 		return
 	}
 
+	firstPage, _ = searchResult.CurrentPage()
+	glossary = firstPage.Entities[0]
+
 	assert.Len(t, searchResult, 1, "number of glossaries should be 1")
-	assert.Equal(t, "g", string((*searchResult[0].Entities[0].DisplayName)[0]), "glossary name should start with G")
+	assert.Equal(t, "g", string((*glossary.DisplayName)[0]), "glossary name should start with G")
 
 	// Delete already created glossary
 	deleteresponse, _ := PurgeByGuid([]string{response.MutatedEntities.CREATE[0].Guid})

--- a/atlan/assets/persona_client.go
+++ b/atlan/assets/persona_client.go
@@ -241,7 +241,7 @@ func FindPersonasByName(name string) (*model.IndexSearchResponse, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error executing search: %v", err)
 		}
-		fmt.Println("Current Page: ", iterator.CurrentPage())
+		fmt.Println("Current Page: ", iterator.CurrentPageNumber())
 		for _, entity := range response.Entities {
 			if *entity.TypeName == "Persona" {
 				return response, err

--- a/atlan/assets/purpose_client.go
+++ b/atlan/assets/purpose_client.go
@@ -206,7 +206,7 @@ func FindPurposesByName(name string) (*model.IndexSearchResponse, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error executing search: %v", err)
 		}
-		fmt.Println("Current Page: ", iterator.CurrentPage())
+		fmt.Println("Current Page: ", iterator.CurrentPageNumber())
 
 		// Check each entity in the current page
 		for _, entity := range response.Entities {

--- a/main.go
+++ b/main.go
@@ -2,44 +2,90 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/atlanhq/atlan-go/atlan/assets"
-	"github.com/atlanhq/atlan-go/atlan/logger"
-	"github.com/atlanhq/atlan-go/atlan/model/structs"
 )
 
 func main() {
 	ctx := assets.NewContext()
 	ctx.EnableLogging("debug")
 
-	miner := assets.NewSnowflakeMiner("default/snowflake/1739484068").
-		S3(
-			"test-s3-bucket",
-			"test-s3-prefix",
-			"TEST_QUERY",
-			"TEST_SNOWFLAKE",
-			"TEST_SCHEMA",
-			"TEST_SESSION_ID",
-			structs.StringPtr("test-s3-bucket-region"),
-		).
-		PopularityWindow(30).
-		NativeLineage(true).
-		CustomConfig(map[string]interface{}{
-			"test":    true,
-			"feature": 1234,
-		}).
-		ToWorkflow()
+	columnSearchResponse := assets.NewFluentSearch().
+		PageSizes(50).
+		Where(ctx.Column.TYPENAME.Eq("Column")).
+		Execute()
 
-	Schedule := structs.WorkflowSchedule{CronSchedule: "45 5 * * *", Timezone: "Europe/Paris"}
-
-	// Run the workflow
-	response, err := ctx.WorkflowClient.Run(miner, &Schedule)
+	// Fetch the first page
+	page, err := columnSearchResponse.CurrentPage()
 	if err != nil {
-		logger.Log.Errorf("Error running workflow: %v", err)
-		return
+		log.Fatal(err)
 	}
-	fmt.Println(response.Spec)
 
+	// Iterate through the assets in the current page
+	for _, asset := range page.Entities {
+		fmt.Println("Asset:", asset)
+	}
+
+	// Iterate through pages until there are no more results
+	for {
+		page, err := columnSearchResponse.CurrentPage() // Fetch the current page (first fetch happens automatically)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Process assets from the current page
+		for _, asset := range page.Entities {
+			fmt.Println("Asset:", asset)
+		}
+
+		// Move to the next page, exit loop if no more results
+		if _, err := columnSearchResponse.NextPage(); err != nil {
+			break
+		}
+	}
+
+	// Iterate over all results across all pages
+	for columnSearchResponse.HasMoreResults() {
+		page, err := columnSearchResponse.NextPage()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Process each asset in the page
+		for _, asset := range page.Entities {
+			fmt.Println("Asset:", asset)
+		}
+	}
+	/*
+		miner := assets.NewSnowflakeMiner("default/snowflake/1739484068").
+			S3(
+				"test-s3-bucket",
+				"test-s3-prefix",
+				"TEST_QUERY",
+				"TEST_SNOWFLAKE",
+				"TEST_SCHEMA",
+				"TEST_SESSION_ID",
+				structs.StringPtr("test-s3-bucket-region"),
+			).
+			PopularityWindow(30).
+			NativeLineage(true).
+			CustomConfig(map[string]interface{}{
+				"test":    true,
+				"feature": 1234,
+			}).
+			ToWorkflow()
+
+		Schedule := structs.WorkflowSchedule{CronSchedule: "45 5 * * *", Timezone: "Europe/Paris"}
+
+		// Run the workflow
+		response, err := ctx.WorkflowClient.Run(miner, &Schedule)
+		if err != nil {
+			logger.Log.Errorf("Error running workflow: %v", err)
+			return
+		}
+		fmt.Println(response.Spec)
+	*/
 	/*
 		workflowJSON := `{
 			"metadata": {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes introduced in this PR -->
This PR adds lazy loading for assets, meaning new pages are only fetched when needed. Previously, Execute() would load all results upfront, which used a lot of memory for large datasets. Now, users can go through the results page by page using CurrentPage() or loop through all pages until they choose to stop.

## Related Issue
<!-- Link any relevant issue or ticket -->
APP-5666

## Checklist
- [ ] My code follows the code style of this project
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All the checks and tests are passing locally
- [ ] I have verified that the changes works as expected

## Further Comments
<!-- If there is anything else you would like to add, please do so here -->
This change is not backward-compatible, so it will be included in a separate release.