### PR TITLE
GOV-548 | Add support to disable users

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: go install gotest.tools/gotestsum@v1.12.0
 
       - name: Run tests
         run: gotestsum --format testdox -- -v ./...

--- a/atlan/assets/atlan_tag_cache_test.go
+++ b/atlan/assets/atlan_tag_cache_test.go
@@ -34,7 +34,11 @@ func TestIntegrationAtlanTagCache_GetIDForName(t *testing.T) {
 	cache := NewAtlanTagCache(client)
 
 	// Ensure the cache is populated
-	resp, _ := GetAll()
+	resp, err := GetAll()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.AtlanTagDefs, "No Atlan tags found in the system")
+	
 	tagName := resp.AtlanTagDefs[0].DisplayName
 
 	// _ = cache.RefreshCache()
@@ -59,7 +63,11 @@ func TestIntegrationAtlanTagCache_GetNameForID(t *testing.T) {
 	cache := NewAtlanTagCache(client)
 
 	// Ensure the cache is populated
-	resp, _ := GetAll()
+	resp, err := GetAll()
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.AtlanTagDefs, "No Atlan tags found in the system")
+	
 	tagName := resp.AtlanTagDefs[0].DisplayName
 	id, err := cache.GetIDForName(tagName)
 	require.NoError(t, err)

--- a/atlan/assets/atlan_tag_cache_test.go
+++ b/atlan/assets/atlan_tag_cache_test.go
@@ -38,7 +38,7 @@ func TestIntegrationAtlanTagCache_GetIDForName(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotEmpty(t, resp.AtlanTagDefs, "No Atlan tags found in the system")
-	
+
 	tagName := resp.AtlanTagDefs[0].DisplayName
 
 	// _ = cache.RefreshCache()
@@ -67,7 +67,7 @@ func TestIntegrationAtlanTagCache_GetNameForID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotEmpty(t, resp.AtlanTagDefs, "No Atlan tags found in the system")
-	
+
 	tagName := resp.AtlanTagDefs[0].DisplayName
 	id, err := cache.GetIDForName(tagName)
 	require.NoError(t, err)

--- a/atlan/assets/client.go
+++ b/atlan/assets/client.go
@@ -41,13 +41,14 @@ var (
 
 // Init initializes the default AtlanClient.
 func Init() error {
+	// Configure client and logger first
+	client, loggerInstance := configureClient()
+
+	// Now retrieve API config (after logger is initialized)
 	apiKey, baseURL := retrieveAPIConfig()
 
 	// Normalize the baseURL
 	baseURL = normalizeURL(baseURL)
-
-	// Configure client and logger
-	client, logger := configureClient()
 
 	// Initialize default AtlanClient
 	DefaultAtlanClient = &AtlanClient{
@@ -55,7 +56,7 @@ func Init() error {
 		host:          baseURL,
 		ApiKey:        apiKey,
 		requestParams: defaultRequestParams(apiKey),
-		logger:        *logger,
+		logger:        *loggerInstance,
 		SearchAssets:  newDefaultSearchAssets(),
 	}
 

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -470,11 +470,8 @@ type UpdateUserRequest struct {
 }
 
 // UpdateUser updates a user's properties.
-//
 // Params:
-//
 // - guid: Unique identifier (GUID) of the user to update.
-//
 // - enabled: Pointer to boolean indicating whether the user should be enabled or disabled.
 //
 // Returns:
@@ -488,10 +485,10 @@ func (uc *UserClient) UpdateUser(guid string, enabled *bool) error {
 		Enabled: enabled,
 	}
 
-	api := &UPDATE_USERS
+	api := UPDATE_USERS
 	api.Path = fmt.Sprintf("users/%s", guid)
 
-	_, err := DefaultAtlanClient.CallAPI(api, nil, requestPayload)
+	_, err := DefaultAtlanClient.CallAPI(&api, nil, requestPayload)
 	if err != nil {
 		return err
 	}

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -521,7 +521,7 @@ func (uc *UserClient) RemoveUser(userName, transferToUserName string, wfCreatorU
 	}
 
 	// Disable the user before deletion (if not already disabled)
-	if *userDetails.Enabled {
+	if userDetails.Enabled == nil || *userDetails.Enabled {
 		enabled := false
 		err = uc.UpdateUser(userDetails.ID, &enabled)
 		if err != nil {

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -466,7 +466,7 @@ func ParseAtlanUser(data interface{}) (AtlanUser, error) {
 
 // UpdateUserRequest represents the request payload for updating a user.
 type UpdateUserRequest struct {
-	Enabled *bool  `json:"enabled"`
+	Enabled *bool `json:"enabled"`
 }
 
 // UpdateUser updates a user's properties.

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -464,6 +464,41 @@ func ParseAtlanUser(data interface{}) (AtlanUser, error) {
 	return user, nil
 }
 
+// UpdateUserRequest represents the request payload for updating a user.
+type UpdateUserRequest struct {
+	Enabled *bool  `json:"enabled"`
+}
+
+// UpdateUser updates a user's properties.
+//
+// Params:
+//
+// - guid: Unique identifier (GUID) of the user to update.
+//
+// - enabled: Pointer to boolean indicating whether the user should be enabled or disabled.
+//
+// Returns:
+//   - An error if any API communication issue occurs.
+func (uc *UserClient) UpdateUser(guid string, enabled *bool) error {
+	if guid == "" {
+		return fmt.Errorf("user GUID cannot be empty")
+	}
+
+	requestPayload := UpdateUserRequest{
+		Enabled: enabled,
+	}
+
+	api := &UPDATE_USERS
+	api.Path = fmt.Sprintf("users/%s", guid)
+
+	_, err := DefaultAtlanClient.CallAPI(api, nil, requestPayload)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // RemoveUser removes a user and transfers their assets to another user.
 // Params:
 //   - userName: The username of the user to be removed.
@@ -483,6 +518,15 @@ func (uc *UserClient) RemoveUser(userName, transferToUserName string, wfCreatorU
 	// Ensure the user can only be deleted if their role is not "admin"
 	if userDetails.WorkspaceRole == "$admin" {
 		return nil, fmt.Errorf("user %s cannot be deleted as they are admin", userName)
+	}
+
+	// Disable the user before deletion (if not already disabled)
+	if *userDetails.Enabled {
+		enabled := false
+		err = uc.UpdateUser(userDetails.ID, &enabled)
+		if err != nil {
+			return nil, fmt.Errorf("failed to disable user before deletion: %w", err)
+		}
 	}
 
 	// Fetch transferee user details

--- a/atlan/assets/user_client_test.go
+++ b/atlan/assets/user_client_test.go
@@ -170,6 +170,7 @@ func testRemoveUserDisablesBeforeDeletion(t *testing.T, userID string, username 
 	// Verify user is enabled before test
 	user, err := client.GetByUsername(username)
 	require.NoError(t, err, "error should be nil while retrieving user before test")
+	assert.NotNil(t, user, "retrieved user should not be nil")
 	if user.Enabled != nil {
 		assert.True(t, *user.Enabled, "user should be enabled before test")
 	}
@@ -177,6 +178,7 @@ func testRemoveUserDisablesBeforeDeletion(t *testing.T, userID string, username 
 	// This verifies the disable-before-delete logic without actually deleting the user
 	userDetails, err := client.GetByUsername(username)
 	require.NoError(t, err, "error should be nil while fetching user details")
+	assert.NotNil(t, userDetails, "retrieved user details should not be nil")
 
 	if userDetails.Enabled == nil || *userDetails.Enabled {
 		enabled := false
@@ -208,6 +210,7 @@ func testRemoveUserHandlesNilEnabled(t *testing.T, userID string, username strin
 	// Get user details
 	userDetails, err := client.GetByUsername(username)
 	require.NoError(t, err, "error should be nil while fetching user details")
+	assert.NotNil(t, userDetails, "retrieved user details should not be nil")
 
 	// This verifies that the code doesn't panic when Enabled is nil
 	if userDetails.Enabled == nil || (userDetails.Enabled != nil && *userDetails.Enabled) {

--- a/atlan/assets/user_client_test.go
+++ b/atlan/assets/user_client_test.go
@@ -33,6 +33,17 @@ func TestIntegrationUserClient(t *testing.T) {
 
 	// Test updating user's role
 	testChangeUserRole(t, createdUser.ID)
+
+	// Test disabling and enabling user
+	testDisableAndEnableUser(t, createdUser.ID, *createdUser.Username)
+
+	// Test that RemoveUser disables user before deletion
+	// Note: This test verifies the disable step but doesn't actually delete the user
+	// to avoid cleanup issues in test environments
+	testRemoveUserDisablesBeforeDeletion(t, createdUser.ID, *createdUser.Username)
+
+	// Test nil Enabled field handling (edge case)
+	testRemoveUserHandlesNilEnabled(t, createdUser.ID, *createdUser.Username)
 }
 
 func getOrCreateTestUser(t *testing.T) *AtlanUser {
@@ -112,4 +123,111 @@ func testChangeUserRole(t *testing.T, userID string) {
 	require.NoError(t, err, "error should be nil while retrieving reverted user")
 	assert.Len(t, users, 1, "exactly one user should be retrieved")
 	assert.Equal(t, revertRole, users[0].WorkspaceRole, "user role ID should match the updated role")
+}
+
+// testDisableAndEnableUser tests the UpdateUser function to disable and enable a user.
+func testDisableAndEnableUser(t *testing.T, userID string, username string) {
+	client := &UserClient{}
+
+	// Test disabling the user
+	enabled := false
+	err := client.UpdateUser(userID, &enabled)
+	require.NoError(t, err, "error should be nil while disabling user")
+
+	// Verify the user is disabled
+	user, err := client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while retrieving disabled user")
+	assert.NotNil(t, user, "retrieved user should not be nil")
+	if user.Enabled != nil {
+		assert.False(t, *user.Enabled, "user should be disabled")
+	}
+
+	// Test enabling the user
+	enabled = true
+	err = client.UpdateUser(userID, &enabled)
+	require.NoError(t, err, "error should be nil while enabling user")
+
+	// Verify the user is enabled
+	user, err = client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while retrieving enabled user")
+	assert.NotNil(t, user, "retrieved user should not be nil")
+	if user.Enabled != nil {
+		assert.True(t, *user.Enabled, "user should be enabled")
+	}
+}
+
+// testRemoveUserDisablesBeforeDeletion tests that RemoveUser disables the user before deletion.
+// This test verifies the disable step but doesn't actually execute the deletion workflow
+// to avoid cleanup issues in test environments.
+func testRemoveUserDisablesBeforeDeletion(t *testing.T, userID string, username string) {
+	client := &UserClient{}
+
+	// First, ensure the user is enabled
+	enabled := true
+	err := client.UpdateUser(userID, &enabled)
+	require.NoError(t, err, "error should be nil while enabling user for test")
+
+	// Verify user is enabled before test
+	user, err := client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while retrieving user before test")
+	if user.Enabled != nil {
+		assert.True(t, *user.Enabled, "user should be enabled before test")
+	}
+
+	// This verifies the disable-before-delete logic without actually deleting the user
+	userDetails, err := client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while fetching user details")
+
+	if userDetails.Enabled == nil || *userDetails.Enabled {
+		enabled := false
+		err = client.UpdateUser(userDetails.ID, &enabled)
+		require.NoError(t, err, "error should be nil while disabling user (simulating RemoveUser behavior)")
+	}
+
+	// Verify the user is now disabled
+	user, err = client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while retrieving disabled user")
+	assert.NotNil(t, user, "retrieved user should not be nil")
+	if user.Enabled != nil {
+		assert.False(t, *user.Enabled, "user should be disabled after disable step")
+	}
+
+	// Re-enable the user for other tests
+	enabled = true
+	err = client.UpdateUser(userID, &enabled)
+	require.NoError(t, err, "error should be nil while re-enabling user after test")
+
+	t.Logf("Successfully verified that user is disabled before deletion step")
+}
+
+// testRemoveUserHandlesNilEnabled tests that the disable logic properly handles
+// the case where the Enabled field is nil (unknown status).
+func testRemoveUserHandlesNilEnabled(t *testing.T, userID string, username string) {
+	client := &UserClient{}
+
+	// Get user details
+	userDetails, err := client.GetByUsername(username)
+	require.NoError(t, err, "error should be nil while fetching user details")
+
+	// This verifies that the code doesn't panic when Enabled is nil
+	if userDetails.Enabled == nil || (userDetails.Enabled != nil && *userDetails.Enabled) {
+		enabled := false
+		err = client.UpdateUser(userDetails.ID, &enabled)
+		require.NoError(t, err, "error should be nil while disabling user (handling nil Enabled)")
+
+		// Verify the user is now disabled
+		user, err := client.GetByUsername(username)
+		require.NoError(t, err, "error should be nil while retrieving disabled user")
+		assert.NotNil(t, user, "retrieved user should not be nil")
+		if user.Enabled != nil {
+			assert.False(t, *user.Enabled, "user should be disabled")
+		}
+
+		// Re-enable the user for other tests
+		enabled = true
+		err = client.UpdateUser(userID, &enabled)
+		require.NoError(t, err, "error should be nil while re-enabling user after test")
+	}
+
+	t.Logf("Successfully verified nil Enabled field handling")
 }

--- a/atlan/model/typedef.go
+++ b/atlan/model/typedef.go
@@ -122,28 +122,28 @@ type AttributeOptions struct {
 
 // AttributeDef represents the definition of an attribute.
 type AttributeDef struct {
-	IsNew                 CustomBool                    `json:"isNew,omitempty"`
-	Cardinality           *atlan.Cardinality            `json:"cardinality,omitempty"`
-	Constraints           *[]map[string]interface{}     `json:"constraints,omitempty"`
-	EnumValues            *[]string                     `json:"enumValues,omitempty"`
-	Description           *string                       `json:"description,omitempty"`
-	DefaultValue          *string                       `json:"defaultValue,omitempty"`
-	DisplayName           *string                       `json:"displayName,omitempty"`
-	Name                  *string                       `json:"name,omitempty"`
-	IncludeInNotification CustomBool                    `json:"includeInNotification,omitempty"`
-	IndexType             *IndexType                    `json:"indexType,omitempty"`
-	IsIndexable           CustomBool                    `json:"isIndexable,omitempty"`
-	IsOptional            CustomBool                    `json:"isOptional,omitempty"`
-	IsUnique              CustomBool                    `json:"isUnique,omitempty"`
-	Options               *AttributeOptions             `json:"options,omitempty"`
-	SearchWeight          *float64                      `json:"searchWeight,omitempty"`
-	SkipScrubbing         CustomBool                    `json:"skipScrubbing,omitempty"`
-	TypeName              *string                       `json:"typeName,omitempty"`
-	ValuesMinCount        *float64                      `json:"valuesMinCount,omitempty"`
-	ValuesMaxCount        *float64                      `json:"valuesMaxCount,omitempty"`
-	IndexTypeESConfig     *map[string]interface{}       `json:"indexTypeESConfig,omitempty"`
-	IndexTypeESFields     *map[string]interface{}       `json:"indexTypeESFields,omitempty"`
-	IsDefaultValueNull    CustomBool                    `json:"isDefaultValueNull,omitempty"`
+	IsNew                 CustomBool                `json:"isNew,omitempty"`
+	Cardinality           *atlan.Cardinality        `json:"cardinality,omitempty"`
+	Constraints           *[]map[string]interface{} `json:"constraints,omitempty"`
+	EnumValues            *[]string                 `json:"enumValues,omitempty"`
+	Description           *string                   `json:"description,omitempty"`
+	DefaultValue          *string                   `json:"defaultValue,omitempty"`
+	DisplayName           *string                   `json:"displayName,omitempty"`
+	Name                  *string                   `json:"name,omitempty"`
+	IncludeInNotification CustomBool                `json:"includeInNotification,omitempty"`
+	IndexType             *IndexType                `json:"indexType,omitempty"`
+	IsIndexable           CustomBool                `json:"isIndexable,omitempty"`
+	IsOptional            CustomBool                `json:"isOptional,omitempty"`
+	IsUnique              CustomBool                `json:"isUnique,omitempty"`
+	Options               *AttributeOptions         `json:"options,omitempty"`
+	SearchWeight          *float64                  `json:"searchWeight,omitempty"`
+	SkipScrubbing         CustomBool                `json:"skipScrubbing,omitempty"`
+	TypeName              *string                   `json:"typeName,omitempty"`
+	ValuesMinCount        *float64                  `json:"valuesMinCount,omitempty"`
+	ValuesMaxCount        *float64                  `json:"valuesMaxCount,omitempty"`
+	IndexTypeESConfig     *map[string]interface{}   `json:"indexTypeESConfig,omitempty"`
+	IndexTypeESFields     *map[string]interface{}   `json:"indexTypeESFields,omitempty"`
+	IsDefaultValueNull    CustomBool                `json:"isDefaultValueNull,omitempty"`
 }
 
 // CustomMetadataDefOptions represents options for customizing metadata definitions.

--- a/atlan/model/typedef.go
+++ b/atlan/model/typedef.go
@@ -141,8 +141,8 @@ type AttributeDef struct {
 	TypeName              *string                       `json:"typeName,omitempty"`
 	ValuesMinCount        *float64                      `json:"valuesMinCount,omitempty"`
 	ValuesMaxCount        *float64                      `json:"valuesMaxCount,omitempty"`
-	IndexTypeESConfig     *map[string]string            `json:"indexTypeESConfig,omitempty"`
-	IndexTypeESFields     *map[string]map[string]string `json:"indexTypeESFields,omitempty"`
+	IndexTypeESConfig     *map[string]interface{}       `json:"indexTypeESConfig,omitempty"`
+	IndexTypeESFields     *map[string]interface{}       `json:"indexTypeESFields,omitempty"`
 	IsDefaultValueNull    CustomBool                    `json:"isDefaultValueNull,omitempty"`
 }
 


### PR DESCRIPTION
## Description
The [RemoveUser](https://github.com/atlanhq/atlan-go/blob/aebd2a1501ea235537c3fad7f0d925764b63f5f4/atlan/assets/user_client.go#L476) flow doesn't disable users before removing them. This causes all the WFs generated to remove user to fail because active users can't be deleted. 

Failing WF run - https://datamesh2.atlan.com/api/orchestration/workflows/default/atln-del-usr-020aa4ab-f52c-4806-96fe-efdc770413f4-17691508ckx6p?tab=workflow&uid=e88dd25b-5105-418e-a5cf-56333028ee5d

After new changes - https://datamesh2.atlan.com/api/orchestration/workflows/default/atln-del-usr-020aa4ab-f52c-4806-96fe-efdc770413f4-176949976wt2s?tab=workflow&uid=1a748afb-9e81-4d11-b113-72ea9e380255

## Related Issue
[GOV-548](https://linear.app/atlan-epd/issue/GOV-548/user-deletion-via-sdk-leaves-red-hat-users-stuck-in-removing)

## Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All the checks and tests are passing locally
- [ ] I have verified that the changes works as expected

## Further Comments
- Integration Test
<img width="1235" height="876" alt="Screenshot 2026-01-27 at 13 53 21" src="https://github.com/user-attachments/assets/3bb0d086-76b7-43f6-8b7a-e79377c85e65" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces user enable/disable support and ensures deletion flows handle active users.
> 
> - Adds `UpdateUser` (payload `UpdateUserRequest`) to toggle a user’s `enabled` state; `RemoveUser` now disables the target user if enabled before running the deletion workflow
> - Adds integration tests covering enable/disable, disable-before-delete behavior, and nil `Enabled` handling; strengthens Atlan tag cache tests
> - Initializes client logger before reading API config in `Init`
> - Widens `AttributeDef` `IndexTypeESConfig`/`IndexTypeESFields` to `map[string]interface{}`
> - CI: pins `gotestsum` to `v1.12.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a68f971167641aeff2459ace1efbb67cdaaaf6a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->