### PR TITLE
fix: handle nil FirstName/LastName in RemoveUser to prevent panic

### DIFF
--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/atlanhq/atlan-go/atlan/model/structs"
@@ -13,6 +14,19 @@ type (
 	AtlanUser  structs.AtlanUser
 	UserClient AtlanClient
 )
+
+// safeFullName safely constructs a full name from optional first/last name pointers.
+// Returns trimmed concatenation, handling nil pointers from SSO/SCIM-provisioned users.
+func safeFullName(first, last *string) string {
+	var f, l string
+	if first != nil {
+		f = *first
+	}
+	if last != nil {
+		l = *last
+	}
+	return strings.TrimSpace(f + " " + l)
+}
 
 type CreateUser struct {
 	Email    string `json:"email"`
@@ -565,13 +579,13 @@ func (uc *UserClient) RemoveUser(userName, transferToUserName string, wfCreatorU
 								Parameters: []structs.NameValuePair{
 									{Name: "user-id", Value: userDetails.ID},
 									{Name: "username", Value: userDetails.Username},
-									{Name: "user-full-name", Value: *userDetails.FirstName + " " + *userDetails.LastName},
+									{Name: "user-full-name", Value: safeFullName(userDetails.FirstName, userDetails.LastName)},
 									{Name: "user-email", Value: userDetails.Email},
 									{Name: "transfer-assets-to-user-id", Value: transferUserDetails.ID},
 									{Name: "transfer-assets-to-username", Value: transferUserDetails.Username},
-									{Name: "transferee-full-name", Value: *transferUserDetails.FirstName + " " + *transferUserDetails.LastName},
+									{Name: "transferee-full-name", Value: safeFullName(transferUserDetails.FirstName, transferUserDetails.LastName)},
 									{Name: "kube-secret-name", Value: "argo-client-creds"},
-									{Name: "wf-creator-full-name", Value: *wfCreatorDetails.FirstName + " " + *wfCreatorDetails.LastName},
+									{Name: "wf-creator-full-name", Value: safeFullName(wfCreatorDetails.FirstName, wfCreatorDetails.LastName)},
 									{Name: "wf-creator-email", Value: wfCreatorDetails.Email},
 								},
 							},


### PR DESCRIPTION
## Summary
- Fixes nil pointer dereference panic in `RemoveUser` when users have empty/nil `FirstName` or `LastName` fields
- Adds `safeFullName` helper that nil-checks `*string` pointers before dereferencing
- Replaces all 3 unsafe dereferences in the Argo workflow payload construction (lines 568, 572, 574)

## Root Cause
`RemoveUser` in `atlan/assets/user_client.go` directly dereferences `*string` pointer fields (`FirstName`, `LastName`) without nil checks when constructing the Argo workflow payload. SSO/SCIM-provisioned users (e.g., Red Hat tenant) can have nil `FirstName`/`LastName`, causing a runtime panic.

## Changes
| File | Change |
|---|---|
| `atlan/assets/user_client.go` | Added `safeFullName(first, last *string) string` helper |
| `atlan/assets/user_client.go` | Replaced 3 unsafe `*ptr` dereferences with `safeFullName()` calls |
| `atlan/assets/user_client.go` | Added `"strings"` import for `strings.TrimSpace` |

## Test plan
- [x] Verify `RemoveUser` works for users with both FirstName and LastName populated
- [x] Verify `RemoveUser` works for users with nil FirstName
- [x] Verify `RemoveUser` works for users with nil LastName
- [x] Verify `RemoveUser` works for users with both nil FirstName and LastName
- [x] `go build ./atlan/assets/` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects string construction for workflow parameters; primary risk is minor behavior differences in full-name formatting.
> 
> **Overview**
> Prevents `RemoveUser` from panicking for SSO/SCIM-provisioned users by adding a `safeFullName(first, last *string)` helper and using it when populating the Argo workflow parameters.
> 
> Also adds the `strings` import and trims constructed names so missing first/last names don’t produce malformed values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b50d1a86b67332bf7ec8d510a44c6932a64461e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->