### PR TITLE
GOV-617 | fix: handle nil FirstName/LastName in RemoveUser to prevent panic#98

### DIFF
--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -497,17 +497,26 @@ func (uc *UserClient) UpdateUser(guid string, enabled *bool) error {
 	return nil
 }
 
-// safeFullName safely constructs a full name from first and last name pointers.
-// It handles nil pointers gracefully and returns a trimmed string.
-func safeFullName(first, last *string) string {
-	var f, l string
-	if first != nil {
-		f = *first
+// safeFullName safely constructs a full name from optional first/last name pointers.
+// Each part is trimmed individually before joining to normalize internal whitespace.
+// Optional fallback values (e.g. username, email) are used when both names are nil or empty.
+func safeFullName(first, last *string, fallbacks ...string) string {
+	var parts []string
+	if first != nil && strings.TrimSpace(*first) != "" {
+		parts = append(parts, strings.TrimSpace(*first))
 	}
-	if last != nil {
-		l = *last
+	if last != nil && strings.TrimSpace(*last) != "" {
+		parts = append(parts, strings.TrimSpace(*last))
 	}
-	return strings.TrimSpace(f + " " + l)
+	if len(parts) > 0 {
+		return strings.Join(parts, " ")
+	}
+	for _, fb := range fallbacks {
+		if strings.TrimSpace(fb) != "" {
+			return strings.TrimSpace(fb)
+		}
+	}
+	return ""
 }
 
 // RemoveUser removes a user and transfers their assets to another user.
@@ -579,13 +588,13 @@ func (uc *UserClient) RemoveUser(userName, transferToUserName string, wfCreatorU
 								Parameters: []structs.NameValuePair{
 									{Name: "user-id", Value: userDetails.ID},
 									{Name: "username", Value: userDetails.Username},
-									{Name: "user-full-name", Value: safeFullName(userDetails.FirstName, userDetails.LastName)},
+									{Name: "user-full-name", Value: safeFullName(userDetails.FirstName, userDetails.LastName, userDetails.Email)},
 									{Name: "user-email", Value: userDetails.Email},
 									{Name: "transfer-assets-to-user-id", Value: transferUserDetails.ID},
 									{Name: "transfer-assets-to-username", Value: transferUserDetails.Username},
-									{Name: "transferee-full-name", Value: safeFullName(transferUserDetails.FirstName, transferUserDetails.LastName)},
+									{Name: "transferee-full-name", Value: safeFullName(transferUserDetails.FirstName, transferUserDetails.LastName, transferUserDetails.Email)},
 									{Name: "kube-secret-name", Value: "argo-client-creds"},
-									{Name: "wf-creator-full-name", Value: safeFullName(wfCreatorDetails.FirstName, wfCreatorDetails.LastName)},
+									{Name: "wf-creator-full-name", Value: safeFullName(wfCreatorDetails.FirstName, wfCreatorDetails.LastName, wfCreatorDetails.Email)},
 									{Name: "wf-creator-email", Value: wfCreatorDetails.Email},
 								},
 							},

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -499,8 +499,8 @@ func (uc *UserClient) UpdateUser(guid string, enabled *bool) error {
 
 // safeFullName safely constructs a full name from optional first/last name pointers.
 // Each part is trimmed individually before joining to normalize internal whitespace.
-// Optional fallback values (e.g. username, email) are used when both names are nil or empty.
-func safeFullName(first, last *string, fallbacks ...string) string {
+// Falls back to the provided fallback (e.g. email) when both names are nil or empty.
+func safeFullName(first, last *string, fallback string) string {
 	var parts []string
 	if first != nil && strings.TrimSpace(*first) != "" {
 		parts = append(parts, strings.TrimSpace(*first))
@@ -511,10 +511,8 @@ func safeFullName(first, last *string, fallbacks ...string) string {
 	if len(parts) > 0 {
 		return strings.Join(parts, " ")
 	}
-	for _, fb := range fallbacks {
-		if strings.TrimSpace(fb) != "" {
-			return strings.TrimSpace(fb)
-		}
+	if strings.TrimSpace(fallback) != "" {
+		return strings.TrimSpace(fallback)
 	}
 	return ""
 }

--- a/atlan/assets/user_client.go
+++ b/atlan/assets/user_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/atlanhq/atlan-go/atlan/model/structs"
@@ -496,6 +497,19 @@ func (uc *UserClient) UpdateUser(guid string, enabled *bool) error {
 	return nil
 }
 
+// safeFullName safely constructs a full name from first and last name pointers.
+// It handles nil pointers gracefully and returns a trimmed string.
+func safeFullName(first, last *string) string {
+	var f, l string
+	if first != nil {
+		f = *first
+	}
+	if last != nil {
+		l = *last
+	}
+	return strings.TrimSpace(f + " " + l)
+}
+
 // RemoveUser removes a user and transfers their assets to another user.
 // Params:
 //   - userName: The username of the user to be removed.
@@ -565,13 +579,13 @@ func (uc *UserClient) RemoveUser(userName, transferToUserName string, wfCreatorU
 								Parameters: []structs.NameValuePair{
 									{Name: "user-id", Value: userDetails.ID},
 									{Name: "username", Value: userDetails.Username},
-									{Name: "user-full-name", Value: *userDetails.FirstName + " " + *userDetails.LastName},
+									{Name: "user-full-name", Value: safeFullName(userDetails.FirstName, userDetails.LastName)},
 									{Name: "user-email", Value: userDetails.Email},
 									{Name: "transfer-assets-to-user-id", Value: transferUserDetails.ID},
 									{Name: "transfer-assets-to-username", Value: transferUserDetails.Username},
-									{Name: "transferee-full-name", Value: *transferUserDetails.FirstName + " " + *transferUserDetails.LastName},
+									{Name: "transferee-full-name", Value: safeFullName(transferUserDetails.FirstName, transferUserDetails.LastName)},
 									{Name: "kube-secret-name", Value: "argo-client-creds"},
-									{Name: "wf-creator-full-name", Value: *wfCreatorDetails.FirstName + " " + *wfCreatorDetails.LastName},
+									{Name: "wf-creator-full-name", Value: safeFullName(wfCreatorDetails.FirstName, wfCreatorDetails.LastName)},
 									{Name: "wf-creator-email", Value: wfCreatorDetails.Email},
 								},
 							},

--- a/atlan/assets/user_client_test.go
+++ b/atlan/assets/user_client_test.go
@@ -237,10 +237,11 @@ func testRemoveUserHandlesNilEnabled(t *testing.T, userID string, username strin
 // TestSafeFullName tests the safeFullName helper function with various nil pointer scenarios.
 func TestSafeFullName(t *testing.T) {
 	tests := []struct {
-		name     string
-		first    *string
-		last     *string
-		expected string
+		name      string
+		first     *string
+		last      *string
+		fallbacks []string
+		expected  string
 	}{
 		{
 			name:     "both first and last name present",
@@ -261,7 +262,7 @@ func TestSafeFullName(t *testing.T) {
 			expected: "Doe",
 		},
 		{
-			name:     "both names nil",
+			name:     "both names nil without fallback",
 			first:    nil,
 			last:     nil,
 			expected: "",
@@ -279,22 +280,57 @@ func TestSafeFullName(t *testing.T) {
 			expected: "John",
 		},
 		{
-			name:     "both names empty strings",
+			name:     "both names empty strings without fallback",
 			first:    stringPtr(""),
 			last:     stringPtr(""),
 			expected: "",
 		},
 		{
-			name:     "names with extra spaces",
+			name:     "names with extra spaces are individually trimmed",
 			first:    stringPtr("  John  "),
 			last:     stringPtr("  Doe  "),
-			expected: "John     Doe",
+			expected: "John Doe",
+		},
+		{
+			name:      "both names nil falls back to email",
+			first:     nil,
+			last:      nil,
+			fallbacks: []string{"john@example.com"},
+			expected:  "john@example.com",
+		},
+		{
+			name:      "both names empty falls back to email",
+			first:     stringPtr(""),
+			last:      stringPtr(""),
+			fallbacks: []string{"john@example.com"},
+			expected:  "john@example.com",
+		},
+		{
+			name:      "both names whitespace-only falls back to email",
+			first:     stringPtr("   "),
+			last:      stringPtr("   "),
+			fallbacks: []string{"john@example.com"},
+			expected:  "john@example.com",
+		},
+		{
+			name:      "names present ignores fallback",
+			first:     stringPtr("John"),
+			last:      stringPtr("Doe"),
+			fallbacks: []string{"john@example.com"},
+			expected:  "John Doe",
+		},
+		{
+			name:      "empty fallback skipped to next",
+			first:     nil,
+			last:      nil,
+			fallbacks: []string{"", "john@example.com"},
+			expected:  "john@example.com",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := safeFullName(tt.first, tt.last)
+			result := safeFullName(tt.first, tt.last, tt.fallbacks...)
 			assert.Equal(t, tt.expected, result, "safeFullName should return the expected value")
 		})
 	}

--- a/atlan/assets/user_client_test.go
+++ b/atlan/assets/user_client_test.go
@@ -3,9 +3,8 @@ package assets
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const UserEmail = "gsdk-test-user@atlan.com"
@@ -233,4 +232,75 @@ func testRemoveUserHandlesNilEnabled(t *testing.T, userID string, username strin
 	}
 
 	t.Logf("Successfully verified nil Enabled field handling")
+}
+
+// TestSafeFullName tests the safeFullName helper function with various nil pointer scenarios.
+func TestSafeFullName(t *testing.T) {
+	tests := []struct {
+		name     string
+		first    *string
+		last     *string
+		expected string
+	}{
+		{
+			name:     "both first and last name present",
+			first:    stringPtr("John"),
+			last:     stringPtr("Doe"),
+			expected: "John Doe",
+		},
+		{
+			name:     "only first name present",
+			first:    stringPtr("John"),
+			last:     nil,
+			expected: "John",
+		},
+		{
+			name:     "only last name present",
+			first:    nil,
+			last:     stringPtr("Doe"),
+			expected: "Doe",
+		},
+		{
+			name:     "both names nil",
+			first:    nil,
+			last:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty first name",
+			first:    stringPtr(""),
+			last:     stringPtr("Doe"),
+			expected: "Doe",
+		},
+		{
+			name:     "empty last name",
+			first:    stringPtr("John"),
+			last:     stringPtr(""),
+			expected: "John",
+		},
+		{
+			name:     "both names empty strings",
+			first:    stringPtr(""),
+			last:     stringPtr(""),
+			expected: "",
+		},
+		{
+			name:     "names with extra spaces",
+			first:    stringPtr("  John  "),
+			last:     stringPtr("  Doe  "),
+			expected: "John     Doe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := safeFullName(tt.first, tt.last)
+			assert.Equal(t, tt.expected, result, "safeFullName should return the expected value")
+		})
+	}
+}
+
+// stringPtr is a helper function to create a pointer to a string.
+func stringPtr(s string) *string {
+	return &s
 }

--- a/atlan/assets/user_client_test.go
+++ b/atlan/assets/user_client_test.go
@@ -237,11 +237,11 @@ func testRemoveUserHandlesNilEnabled(t *testing.T, userID string, username strin
 // TestSafeFullName tests the safeFullName helper function with various nil pointer scenarios.
 func TestSafeFullName(t *testing.T) {
 	tests := []struct {
-		name      string
-		first     *string
-		last      *string
-		fallbacks []string
-		expected  string
+		name     string
+		first    *string
+		last     *string
+		fallback string
+		expected string
 	}{
 		{
 			name:     "both first and last name present",
@@ -292,45 +292,38 @@ func TestSafeFullName(t *testing.T) {
 			expected: "John Doe",
 		},
 		{
-			name:      "both names nil falls back to email",
-			first:     nil,
-			last:      nil,
-			fallbacks: []string{"john@example.com"},
-			expected:  "john@example.com",
+			name:     "both names nil falls back to email",
+			first:    nil,
+			last:     nil,
+			fallback: "john@example.com",
+			expected: "john@example.com",
 		},
 		{
-			name:      "both names empty falls back to email",
-			first:     stringPtr(""),
-			last:      stringPtr(""),
-			fallbacks: []string{"john@example.com"},
-			expected:  "john@example.com",
+			name:     "both names empty falls back to email",
+			first:    stringPtr(""),
+			last:     stringPtr(""),
+			fallback: "john@example.com",
+			expected: "john@example.com",
 		},
 		{
-			name:      "both names whitespace-only falls back to email",
-			first:     stringPtr("   "),
-			last:      stringPtr("   "),
-			fallbacks: []string{"john@example.com"},
-			expected:  "john@example.com",
+			name:     "both names whitespace-only falls back to email",
+			first:    stringPtr("   "),
+			last:     stringPtr("   "),
+			fallback: "john@example.com",
+			expected: "john@example.com",
 		},
 		{
-			name:      "names present ignores fallback",
-			first:     stringPtr("John"),
-			last:      stringPtr("Doe"),
-			fallbacks: []string{"john@example.com"},
-			expected:  "John Doe",
-		},
-		{
-			name:      "empty fallback skipped to next",
-			first:     nil,
-			last:      nil,
-			fallbacks: []string{"", "john@example.com"},
-			expected:  "john@example.com",
+			name:     "names present ignores fallback",
+			first:    stringPtr("John"),
+			last:     stringPtr("Doe"),
+			fallback: "john@example.com",
+			expected: "John Doe",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := safeFullName(tt.first, tt.last, tt.fallbacks...)
+			result := safeFullName(tt.first, tt.last, tt.fallback)
 			assert.Equal(t, tt.expected, result, "safeFullName should return the expected value")
 		})
 	}


### PR DESCRIPTION
## Description
Fixes a nil pointer dereference in the `RemoveUser` function when `FirstName` or `LastName` fields are nil, which commonly occurs with SSO/SCIM-provisioned users.

This is resolved by:
- Introducing a `safeFullName` helper function to safely construct full names, handling nil `*string` pointers gracefully.
- Replacing direct dereferences of `FirstName` and `LastName` in `RemoveUser` with calls to `safeFullName`.
- Adding comprehensive unit tests for the `safeFullName` helper.

## Related Issue
GOV-617

## Checklist
- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes (if applicable)
- [x] All the checks and tests are passing locally
- [x] I have verified that the changes works as expected



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects string construction for workflow arguments; primary risk is minor behavior changes in displayed names (email fallback/whitespace trimming).
> 
> **Overview**
> Fixes a potential panic in `UserClient.RemoveUser` when `FirstName`/`LastName` are `nil` by introducing `safeFullName` (trims parts and falls back to email) and using it for workflow parameters (`user-full-name`, `transferee-full-name`, `wf-creator-full-name`).
> 
> Adds unit tests covering `safeFullName` across nil/empty/whitespace inputs, plus a small import-order cleanup in the test file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bdab8cc57a3d4f720d7ac3cb34c2f3512c4fbac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->