### PR TITLE
feat(announcements): optional AnnouncementExpiredAt field (DES-1500)

### DIFF
--- a/atlan/model/structs/asset.go
+++ b/atlan/model/structs/asset.go
@@ -85,6 +85,8 @@ type Asset struct {
 	AnnouncementUpdatedAt *int64 `json:"announcementUpdatedAt,omitempty"`
 	// Name of the user who last updated the announcement.
 	AnnouncementUpdatedBy *string `json:"announcementUpdatedBy,omitempty"`
+	// Time (epoch) at which the announcement expires, in milliseconds.
+	AnnouncementExpiredAt *int64 `json:"announcementExpiredAt,omitempty"`
 	// Name of the account in which this asset exists in dbt.
 	AssetDbtAccountName *string `json:"assetDbtAccountName,omitempty"`
 	// Alias of this asset in dbt.


### PR DESCRIPTION
## Summary

Adds `AnnouncementExpiredAt` to the `Asset` struct, matching the new field added to the Atlan platform in DES-1500.

## Changes

**`atlan/model/structs/asset.go`**
- Added `AnnouncementExpiredAt *int64 \`json:"announcementExpiredAt,omitempty"\`` following the same pattern as `AnnouncementUpdatedAt`

## Usage

```go
expiredAt := int64(1748736000000) // 2026-06-01 00:00:00 UTC in ms

asset := &structs.Asset{
    AnnouncementTitle:    strPtr("Caution!"),
    AnnouncementType:     &atlan.AnnouncementTypeWARNING,
    AnnouncementMessage:  strPtr("This table is changing."),
    AnnouncementExpiredAt: &expiredAt,
}
```

## Notes

- The Go SDK does not yet have `UpdateAnnouncement` / `RemoveAnnouncement` convenience methods; this struct field is the appropriate level of change for now
- Field is `omitempty` so existing code serializing `Asset` structs is unaffected

## Test plan

- [ ] Existing code that serializes/deserializes `Asset` structs is unaffected
- [ ] `AnnouncementExpiredAt` round-trips correctly through JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)